### PR TITLE
ci: use private GitHub App for releases

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -25,16 +25,32 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  create-release-pr:
+  preflight:
     runs-on: ubuntu-latest
+    outputs:
+      release_token_available: ${{ steps.release-token.outputs.available }}
     steps:
-      - name: Validate release token
+      - name: Check release token
+        id: release-token
         run: |
-          if [ -z "${GH_TOKEN}" ]; then
+          if [ -n "${GH_TOKEN}" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "::error title=Missing RELEASE_TOKEN::Configure the release bot token as the RELEASE_TOKEN repository secret."
             exit 1
           fi
 
+          echo "::notice title=Release automation skipped::Configure RELEASE_TOKEN to enable release PR creation. GITHUB_TOKEN is intentionally not used because pushes made with it do not trigger downstream workflows."
+          echo "available=false" >> "$GITHUB_OUTPUT"
+
+  create-release-pr:
+    needs: preflight
+    if: needs.preflight.outputs.release_token_available == 'true'
+    runs-on: ubuntu-latest
+    steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -16,10 +16,6 @@ permissions:
   contents: write
   pull-requests: write
 
-env:
-  # Use a release bot token so release/next pushes and tag pushes trigger normal workflow fanout.
-  GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-
 concurrency:
   group: release-pr-main
   cancel-in-progress: true
@@ -32,18 +28,21 @@ jobs:
     steps:
       - name: Check release token
         id: release-token
+        env:
+          RELEASE_APP_ID: ${{ secrets.RELEASE_APP_ID }}
+          RELEASE_APP_PRIVATE_KEY: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
         run: |
-          if [ -n "${GH_TOKEN}" ]; then
+          if [ -n "${RELEASE_APP_ID}" ] && [ -n "${RELEASE_APP_PRIVATE_KEY}" ]; then
             echo "available=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "::error title=Missing RELEASE_TOKEN::Configure the release bot token as the RELEASE_TOKEN repository secret."
+            echo "::error title=Missing release app secrets::Configure RELEASE_APP_ID and RELEASE_APP_PRIVATE_KEY repository secrets."
             exit 1
           fi
 
-          echo "::notice title=Release automation skipped::Configure RELEASE_TOKEN to enable release PR creation. GITHUB_TOKEN is intentionally not used because pushes made with it do not trigger downstream workflows."
+          echo "::notice title=Release automation skipped::Configure RELEASE_APP_ID and RELEASE_APP_PRIVATE_KEY to enable release PR creation. GITHUB_TOKEN is intentionally not used because pushes made with it do not trigger downstream workflows."
           echo "available=false" >> "$GITHUB_OUTPUT"
 
   create-release-pr:
@@ -51,11 +50,18 @@ jobs:
     if: needs.preflight.outputs.release_token_available == 'true'
     runs-on: ubuntu-latest
     steps:
+      - name: Create release app token
+        id: release-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ env.GH_TOKEN }}
+          token: ${{ steps.release-token.outputs.token }}
 
       - name: Skip release commits
         id: skip
@@ -220,6 +226,8 @@ jobs:
       - name: Find existing release PR
         if: steps.skip.outputs.skip == 'false' && steps.changes.outputs.ahead != '0' && steps.version-check.outputs.skip == 'false'
         id: existing-pr
+        env:
+          GH_TOKEN: ${{ steps.release-token.outputs.token }}
         run: |
           pr_number="$(gh pr list \
             --base "${{ github.event.repository.default_branch }}" \
@@ -233,6 +241,7 @@ jobs:
       - name: Create release PR
         if: steps.skip.outputs.skip == 'false' && steps.changes.outputs.ahead != '0' && steps.version-check.outputs.skip == 'false' && steps.existing-pr.outputs.pr_number == ''
         env:
+          GH_TOKEN: ${{ steps.release-token.outputs.token }}
           RELEASE_TAG: ${{ steps.normalized-version.outputs.tag }}
         run: |
           gh pr create \
@@ -244,6 +253,7 @@ jobs:
       - name: Update existing release PR
         if: steps.skip.outputs.skip == 'false' && steps.changes.outputs.ahead != '0' && steps.version-check.outputs.skip == 'false' && steps.existing-pr.outputs.pr_number != ''
         env:
+          GH_TOKEN: ${{ steps.release-token.outputs.token }}
           RELEASE_TAG: ${{ steps.normalized-version.outputs.tag }}
         run: |
           gh pr edit "${{ steps.existing-pr.outputs.pr_number }}" \

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -8,10 +8,6 @@ on:
 permissions:
   contents: write
 
-env:
-  # Use a release bot token so tag pushes trigger the release workflow.
-  RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-
 concurrency:
   group: release-tag-${{ github.event.pull_request.number }}
   cancel-in-progress: false
@@ -21,19 +17,19 @@ jobs:
     if: github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'release/next' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
-      - name: Validate release token
-        run: |
-          if [ -z "${RELEASE_TOKEN}" ]; then
-            echo "::error title=Missing RELEASE_TOKEN::Configure the release bot token as the RELEASE_TOKEN repository secret."
-            exit 1
-          fi
+      - name: Create release app token
+        id: release-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.merge_commit_sha }}
-          token: ${{ env.RELEASE_TOKEN }}
+          token: ${{ steps.release-token.outputs.token }}
 
       - name: Determine release tag
         id: release

--- a/README.md
+++ b/README.md
@@ -109,4 +109,6 @@ Merges to `main` create or update a `release/next` pull request with a generated
 publishes a GitHub release.
 
 The release workflows require a repository secret named `RELEASE_TOKEN` with
-permission to push branches and tags.
+permission to push branches and tags. The release PR workflow intentionally does
+not use the default `GITHUB_TOKEN` for release branch pushes because events
+created with that token do not trigger normal downstream workflow runs.

--- a/README.md
+++ b/README.md
@@ -108,7 +108,9 @@ Merges to `main` create or update a `release/next` pull request with a generated
 `CHANGELOG.md` entry. Merging that release PR creates a `vX.Y.Z` tag and
 publishes a GitHub release.
 
-The release workflows require a repository secret named `RELEASE_TOKEN` with
-permission to push branches and tags. The release PR workflow intentionally does
-not use the default `GITHUB_TOKEN` for release branch pushes because events
-created with that token do not trigger normal downstream workflow runs.
+The release workflows require a private GitHub App installed on this repository
+with `Contents: write` and `Pull requests: write` permissions. Store its app ID
+and private key as repository secrets named `RELEASE_APP_ID` and
+`RELEASE_APP_PRIVATE_KEY`. The release PR workflow intentionally does not use
+the default `GITHUB_TOKEN` for release branch pushes because events created with
+that token do not trigger normal downstream workflow runs.


### PR DESCRIPTION
## Summary

- switch release PR/tag automation from a long-lived `RELEASE_TOKEN` secret to a private GitHub App installation token
- keep release automation skipped on normal push/schedule runs when app secrets are absent, while failing manual release attempts clearly
- document the required private GitHub App secrets and why the default `GITHUB_TOKEN` is not used

## Why

`GITHUB_TOKEN` can push branches and tags, but events created with it do not trigger normal downstream workflow runs. The release flow needs fanout from `release/next` branch pushes and `v*` tag pushes, so it now mints a short-lived installation token from `er-release-bot`.

## Verification

- `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].sort.each { |f| YAML.load_file(f); puts f }'`
- `git diff --check`

## Setup Completed

- Created private GitHub App: `er-release-bot`
- Installed it on `darwin67/er`
- Stored repo secrets:
  - `RELEASE_APP_ID`
  - `RELEASE_APP_PRIVATE_KEY`
