### PR TITLE
feat(content): support Mermaid diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Checkout the [demo](https://er-6wj.pages.dev).
 - Tag and category pages
 - Collapsible table of contents at the top of each post (built from Hugo's native `.TableOfContents`)
 - Light and dark mode with a `clay` (warm-earth) or `nord` (arctic) color palette
+- Mermaid diagrams in Markdown and Org content
 <!-- - Renders Math with KaTeX -->
 - Tag cloud on big screens
 - Hugo multilingual sites
@@ -106,6 +107,36 @@ params:
 ```
 
 If unset, the site uses `clay`.
+
+### Mermaid diagrams
+
+Use a fenced `mermaid` code block in Markdown:
+
+````markdown
+```mermaid
+flowchart LR
+    Write --> Build --> Publish
+```
+````
+
+In Org content, use a Mermaid source block:
+
+```org
+#+BEGIN_SRC mermaid
+flowchart LR
+    Write --> Build --> Publish
+#+END_SRC
+```
+
+Mermaid is loaded only on pages that contain a diagram. Diagrams follow the
+active color palette and are re-rendered after a light or dark mode change.
+The theme uses Mermaid 11.15.0 from jsDelivr by default. To self-host it or pin
+another compatible build, set the ESM module URL:
+
+```yaml
+params:
+  mermaidURL: /js/mermaid.esm.min.mjs
+```
 
 ### Favicon
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,18 @@ flowchart LR
 
 Mermaid is loaded only on pages that contain a diagram. Diagrams follow the
 active color palette and are re-rendered after a light or dark mode change.
+
+The default look is `classic`. Set `mermaidLook` to `handDrawn` for an
+Excalidraw-like appearance, or to `neo` for Mermaid's modern style. When using
+`handDrawn`, the fixed drawing seed keeps lines stable across re-renders; change
+it to produce a different variation:
+
+```yaml
+params:
+  mermaidLook: handDrawn
+  mermaidHandDrawnSeed: 12
+```
+
 The theme uses Mermaid 11.15.0 from jsDelivr by default. To self-host it or pin
 another compatible build, set the ESM module URL:
 

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -259,6 +259,7 @@ html { scroll-behavior: smooth; }
 .post-content pre,
 .post-content .highlight,
 .post-content .code-block,
+.post-content .mermaid,
 .post-content figure,
 .post-content table,
 .post-content .pullquote,
@@ -326,6 +327,20 @@ pre code {
   background-color: transparent;
   color: inherit;
   padding: 0;
+}
+
+.post-content pre.mermaid {
+  display: flex;
+  justify-content: center;
+  padding: 1.5rem;
+  border: 1px solid var(--color-border);
+  background-color: var(--color-background-alt);
+  text-align: center;
+}
+
+.post-content .mermaid svg {
+  max-width: 100%;
+  height: auto;
 }
 
 /* Wrapper added at runtime by code-copy.js so we can pin the language label
@@ -909,4 +924,3 @@ td {
   color: var(--color-muted-text);
   margin-top: 0.25rem;
 }
-

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -46,6 +46,7 @@
     --color-background: #fff;
     --color-main-light: #a87266;
     --color-main-dark: #704e44;
+    --color-secondary-light: #c4e0bf;
     --color-secondary-dark: #8fb88a;
     --color-background-alt: #f5f5f5;
     --color-border: #e8e8e8;
@@ -2027,7 +2028,7 @@ html {
   margin-left: auto;
   margin-right: auto;
 }
-.post-content pre, .post-content .highlight, .post-content .code-block, .post-content figure, .post-content table, .post-content .pullquote, .post-content .callout, .post-content img, .post-content p:has(> img:only-child) {
+.post-content pre, .post-content .highlight, .post-content .code-block, .post-content .mermaid, .post-content figure, .post-content table, .post-content .pullquote, .post-content .callout, .post-content img, .post-content p:has(> img:only-child) {
   max-width: var(--max-width-wide);
   margin-left: auto;
   margin-right: auto;
@@ -2092,6 +2093,18 @@ pre code {
   background-color: transparent;
   color: inherit;
   padding: 0;
+}
+.post-content pre.mermaid {
+  display: flex;
+  justify-content: center;
+  padding: 1.5rem;
+  border: 1px solid var(--color-border);
+  background-color: var(--color-background-alt);
+  text-align: center;
+}
+.post-content .mermaid svg {
+  max-width: 100%;
+  height: auto;
 }
 .code-block {
   position: relative;

--- a/demo/content/posts/mermaid-markdown.md
+++ b/demo/content/posts/mermaid-markdown.md
@@ -11,7 +11,8 @@ description: "Flowcharts and sequence diagrams rendered from fenced Mermaid bloc
 ---
 
 Mermaid diagrams can live beside prose as ordinary fenced code blocks. The
-theme loads Mermaid only when a page contains at least one diagram.
+theme loads Mermaid only when a page contains at least one diagram and gives
+the result a hand-drawn appearance.
 
 ## Publishing workflow
 

--- a/demo/content/posts/mermaid-markdown.md
+++ b/demo/content/posts/mermaid-markdown.md
@@ -1,0 +1,44 @@
+---
+title: "Mermaid Diagrams in Markdown"
+date: 2025-10-12
+tags:
+  - mermaid
+  - diagrams
+  - markdown
+categories:
+  - documentation
+description: "Flowcharts and sequence diagrams rendered from fenced Mermaid blocks."
+---
+
+Mermaid diagrams can live beside prose as ordinary fenced code blocks. The
+theme loads Mermaid only when a page contains at least one diagram.
+
+## Publishing workflow
+
+This flowchart shows a small documentation pipeline:
+
+```mermaid
+flowchart LR
+    A[Write Markdown] --> B{Preview locally}
+    B -->|Needs work| A
+    B -->|Looks good| C[Build with Hugo]
+    C --> D[Deploy site]
+```
+
+## Request lifecycle
+
+Sequence diagrams are useful for documenting interactions between services:
+
+```mermaid
+sequenceDiagram
+    actor Reader
+    participant Browser
+    participant HugoSite as Hugo site
+    Reader->>Browser: Open an article
+    Browser->>HugoSite: Request generated page
+    HugoSite-->>Browser: Return HTML
+    Browser->>Browser: Render Mermaid diagram
+    Browser-->>Reader: Display the article
+```
+
+The same blocks follow the selected light or dark color palette.

--- a/demo/content/posts/mermaid-org.org
+++ b/demo/content/posts/mermaid-org.org
@@ -1,0 +1,46 @@
+#+TITLE: Mermaid Diagrams in Org Mode
+#+DATE: <2025-10-13 Mon>
+#+TAGS[]: mermaid diagrams orgmode
+#+CATEGORY: Documentation
+#+DESCRIPTION: State and entity relationship diagrams rendered from Org source blocks.
+
+Mermaid also works in Org content. Use a source block whose language is
+=mermaid=; the theme converts Hugo's highlighted Org output before rendering
+the diagram.
+
+* Release states
+
+State diagrams can summarize a workflow without maintaining a separate image:
+
+#+BEGIN_SRC mermaid
+stateDiagram-v2
+    [*] --> Draft
+    Draft --> Review: Open pull request
+    Review --> Draft: Request changes
+    Review --> Published: Approve and merge
+    Published --> [*]
+#+END_SRC
+
+* Content model
+
+Entity relationship diagrams are useful for describing structured content:
+
+#+BEGIN_SRC mermaid
+erDiagram
+    AUTHOR ||--o{ POST : writes
+    POST }o--o{ TAG : uses
+    AUTHOR {
+        string name
+        string email
+    }
+    POST {
+        string title
+        date published
+    }
+    TAG {
+        string name
+    }
+#+END_SRC
+
+Like the Markdown examples, these diagrams use the site's active palette and
+are re-rendered when the light or dark theme changes.

--- a/demo/content/posts/mermaid-org.org
+++ b/demo/content/posts/mermaid-org.org
@@ -43,4 +43,4 @@ erDiagram
 #+END_SRC
 
 Like the Markdown examples, these diagrams use the site's active palette and
-are re-rendered when the light or dark theme changes.
+hand-drawn style, and are re-rendered when the light or dark theme changes.

--- a/demo/hugo.yaml
+++ b/demo/hugo.yaml
@@ -63,6 +63,8 @@ markup:
 params:
   search: true
   showFeaturedProjects: true
+  mermaidLook: handDrawn
+  mermaidHandDrawnSeed: 7
   # palette: nord
 
 outputs:

--- a/layouts/_markup/render-codeblock-mermaid.html
+++ b/layouts/_markup/render-codeblock-mermaid.html
@@ -1,0 +1,4 @@
+{{- .Page.Store.Set "hasMermaid" true -}}
+<pre class="mermaid">
+  {{- .Inner | htmlEscape | safeHTML -}}
+</pre>

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -100,3 +100,86 @@ document.addEventListener('DOMContentLoaded', function() {
           throwOnError: false
         });"></script>
 {{end}}
+
+{{- $hasMermaid := .Store.Get "hasMermaid" -}}
+{{- if .IsPage -}}
+  {{- $orgMermaidBlocks := findRE `(?im)^#\+begin_src[[:space:]]+mermaid(?:[[:space:]]|$)` .RawContent 1 -}}
+  {{- $hasMermaid = or $hasMermaid (gt (len $orgMermaidBlocks) 0) -}}
+{{- end -}}
+{{- if $hasMermaid }}
+<script type="module">
+import mermaid from '{{ .Site.Params.mermaidURL | default "https://cdn.jsdelivr.net/npm/mermaid@11.15.0/dist/mermaid.esm.min.mjs" }}';
+
+// go-org renders source blocks through Hugo's highlighter. Restore the
+// original text shape Mermaid expects before rendering the diagrams.
+document.querySelectorAll('.src-mermaid').forEach(function(block) {
+  var source = block.querySelector('pre');
+  if (!source) return;
+
+  var diagram = document.createElement('pre');
+  diagram.className = 'mermaid';
+  diagram.textContent = source.textContent;
+  block.replaceWith(diagram);
+});
+
+var diagrams = Array.from(document.querySelectorAll('pre.mermaid'));
+diagrams.forEach(function(diagram) {
+  diagram.dataset.mermaidSource = diagram.textContent.trim();
+});
+
+function themeVariables() {
+  var styles = getComputedStyle(document.documentElement);
+  var color = function(name) {
+    return styles.getPropertyValue(name).trim();
+  };
+
+  return {
+    background: color('--color-background'),
+    primaryColor: color('--color-background-alt'),
+    primaryTextColor: color('--color-body-text'),
+    primaryBorderColor: color('--color-main'),
+    lineColor: color('--color-muted-text'),
+    secondaryColor: color('--color-secondary-light'),
+    tertiaryColor: color('--color-background'),
+    noteBkgColor: color('--color-background-alt'),
+    noteTextColor: color('--color-body-text'),
+    noteBorderColor: color('--color-border')
+  };
+}
+
+var renderQueue = Promise.resolve();
+
+function renderMermaid() {
+  renderQueue = renderQueue.catch(function(error) {
+    console.error('Unable to render Mermaid diagram:', error);
+  }).then(async function() {
+    diagrams.forEach(function(diagram) {
+      diagram.removeAttribute('data-processed');
+      diagram.textContent = diagram.dataset.mermaidSource;
+    });
+
+    mermaid.initialize({
+      startOnLoad: false,
+      securityLevel: 'strict',
+      theme: 'base',
+      themeVariables: themeVariables()
+    });
+    await mermaid.run({ nodes: diagrams });
+  });
+}
+
+renderMermaid();
+
+new MutationObserver(function(mutations) {
+  if (mutations.some(function(mutation) {
+    return mutation.attributeName === 'data-theme' ||
+      mutation.attributeName === 'data-palette';
+  })) {
+    renderMermaid();
+  }
+}).observe(document.documentElement, {
+  attributes: true,
+  attributeFilter: ['data-theme', 'data-palette']
+});
+</script>
+{{- end }}

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -107,6 +107,10 @@ document.addEventListener('DOMContentLoaded', function() {
   {{- $hasMermaid = or $hasMermaid (gt (len $orgMermaidBlocks) 0) -}}
 {{- end -}}
 {{- if $hasMermaid }}
+{{- $mermaidLook := .Site.Params.mermaidLook | default "classic" -}}
+{{- if not (in (slice "classic" "handDrawn" "neo") $mermaidLook) -}}
+  {{- errorf "Invalid params.mermaidLook %q: expected classic, handDrawn, or neo" $mermaidLook -}}
+{{- end -}}
 <script type="module">
 import mermaid from '{{ .Site.Params.mermaidURL | default "https://cdn.jsdelivr.net/npm/mermaid@11.15.0/dist/mermaid.esm.min.mjs" }}';
 
@@ -162,6 +166,8 @@ function renderMermaid() {
       startOnLoad: false,
       securityLevel: 'strict',
       theme: 'base',
+      look: {{ $mermaidLook | jsonify | safeJS }},
+      handDrawnSeed: {{ .Site.Params.mermaidHandDrawnSeed | default 7 }},
       themeVariables: themeVariables()
     });
     await mermaid.run({ nodes: diagrams });

--- a/static/js/code-copy.js
+++ b/static/js/code-copy.js
@@ -59,6 +59,8 @@
 
   document.addEventListener('DOMContentLoaded', function () {
     var nodes = document.querySelectorAll('.post-content pre');
-    nodes.forEach(enhance);
+    nodes.forEach(function (pre) {
+      if (!pre.closest('.mermaid, .src-mermaid')) enhance(pre);
+    });
   });
 })();


### PR DESCRIPTION
## Summary

- render fenced `mermaid` blocks in Markdown and Mermaid source blocks in Org content
- load Mermaid only on pages that contain diagrams and keep diagrams aligned with the active color palette
- support configurable `classic`, `handDrawn`, and `neo` looks, with a stable hand-drawn seed
- add Markdown and Org demo posts plus usage documentation

## Configuration

```yaml
params:
  mermaidLook: handDrawn # classic | handDrawn | neo
  mermaidHandDrawnSeed: 7
```

The default look remains `classic`; the demo opts into `handDrawn`.

## Verification

- `nix develop -c make build`
- Hugo build for the multilingual demo
- Pagefind indexing for the demo
- generated HTML assertions for Markdown, Org, conditional loading, and style configuration
- validation that unsupported `mermaidLook` values fail with a clear build error