### PR TITLE
fix(content): improve Mermaid styling and dark mode contrast

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1,6 +1,6 @@
 @import "tailwindcss";
 @plugin '@tailwindcss/typography';
-@source inline("prose-lg prose-sm callout callout-note callout-tip callout-warn callout-danger dropcap");
+@source inline("prose-lg prose-sm callout callout-note callout-tip callout-warn callout-danger dropcap flex justify-center max-w-[var(--max-width-wide)] mx-auto p-6 border border-[var(--color-border)] rounded bg-[var(--color-background-alt)] text-center");
 
 /* Layout + typography constants are palette-independent. */
 @theme {
@@ -256,10 +256,9 @@ html { scroll-behavior: smooth; }
 /* Code, tables, figures, images, callouts, and pullquotes get the full
    canvas. `:has(> img:only-child)` widens paragraphs that wrap a lone
    image (Hugo's default for plain markdown `![](…)`). */
-.post-content pre,
+.post-content pre:not(.mermaid),
 .post-content .highlight,
 .post-content .code-block,
-.post-content .mermaid,
 .post-content figure,
 .post-content table,
 .post-content .pullquote,
@@ -327,15 +326,6 @@ pre code {
   background-color: transparent;
   color: inherit;
   padding: 0;
-}
-
-.post-content pre.mermaid {
-  display: flex;
-  justify-content: center;
-  padding: 1.5rem;
-  border: 1px solid var(--color-border);
-  background-color: var(--color-background-alt);
-  text-align: center;
 }
 
 .post-content .mermaid svg {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1180,6 +1180,9 @@
   .max-w-\[650px\] {
     max-width: 650px;
   }
+  .max-w-\[var\(--max-width-wide\)\] {
+    max-width: var(--max-width-wide);
+  }
   .max-w-full {
     max-width: 100%;
   }
@@ -1302,6 +1305,9 @@
   }
   .p-3 {
     padding: calc(var(--spacing) * 3);
+  }
+  .p-6 {
+    padding: calc(var(--spacing) * 6);
   }
   .px-1 {
     padding-inline: calc(var(--spacing) * 1);
@@ -2028,7 +2034,7 @@ html {
   margin-left: auto;
   margin-right: auto;
 }
-.post-content pre, .post-content .highlight, .post-content .code-block, .post-content .mermaid, .post-content figure, .post-content table, .post-content .pullquote, .post-content .callout, .post-content img, .post-content p:has(> img:only-child) {
+.post-content pre:not(.mermaid), .post-content .highlight, .post-content .code-block, .post-content figure, .post-content table, .post-content .pullquote, .post-content .callout, .post-content img, .post-content p:has(> img:only-child) {
   max-width: var(--max-width-wide);
   margin-left: auto;
   margin-right: auto;
@@ -2093,14 +2099,6 @@ pre code {
   background-color: transparent;
   color: inherit;
   padding: 0;
-}
-.post-content pre.mermaid {
-  display: flex;
-  justify-content: center;
-  padding: 1.5rem;
-  border: 1px solid var(--color-border);
-  background-color: var(--color-background-alt);
-  text-align: center;
 }
 .post-content .mermaid svg {
   max-width: 100%;

--- a/layouts/_markup/render-codeblock-mermaid.html
+++ b/layouts/_markup/render-codeblock-mermaid.html
@@ -1,4 +1,4 @@
 {{- .Page.Store.Set "hasMermaid" true -}}
-<pre class="mermaid">
+<pre class="mermaid flex justify-center max-w-[var(--max-width-wide)] mx-auto p-6 border border-[var(--color-border)] rounded bg-[var(--color-background-alt)] text-center">
   {{- .Inner | htmlEscape | safeHTML -}}
 </pre>

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -121,7 +121,7 @@ document.querySelectorAll('.src-mermaid').forEach(function(block) {
   if (!source) return;
 
   var diagram = document.createElement('pre');
-  diagram.className = 'mermaid';
+  diagram.className = 'mermaid flex justify-center max-w-[var(--max-width-wide)] mx-auto p-6 border border-[var(--color-border)] rounded bg-[var(--color-background-alt)] text-center';
   diagram.textContent = source.textContent;
   block.replaceWith(diagram);
 });

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -133,21 +133,67 @@ diagrams.forEach(function(diagram) {
 
 function themeVariables() {
   var styles = getComputedStyle(document.documentElement);
+  var darkMode = document.documentElement.getAttribute('data-theme') === 'dark';
   var color = function(name) {
     return styles.getPropertyValue(name).trim();
   };
+  var background = color('--color-background');
+  var backgroundAlt = color('--color-background-alt');
+  var bodyText = color('--color-body-text');
+  var border = color('--color-border');
+  var main = color('--color-main');
+  var muted = color('--color-muted-text');
+  var secondary = color('--color-secondary-light');
 
+  // Mermaid otherwise derives light-mode labels and hardcodes light ER rows.
   return {
-    background: color('--color-background'),
-    primaryColor: color('--color-background-alt'),
-    primaryTextColor: color('--color-body-text'),
-    primaryBorderColor: color('--color-main'),
-    lineColor: color('--color-muted-text'),
-    secondaryColor: color('--color-secondary-light'),
-    tertiaryColor: color('--color-background'),
-    noteBkgColor: color('--color-background-alt'),
-    noteTextColor: color('--color-body-text'),
-    noteBorderColor: color('--color-border')
+    darkMode: darkMode,
+    fontFamily: color('--font-sans'),
+    background: background,
+    primaryColor: backgroundAlt,
+    primaryTextColor: bodyText,
+    primaryBorderColor: main,
+    secondaryColor: secondary,
+    secondaryTextColor: darkMode ? background : bodyText,
+    secondaryBorderColor: color('--color-secondary-dark'),
+    tertiaryColor: background,
+    tertiaryTextColor: bodyText,
+    tertiaryBorderColor: border,
+    lineColor: muted,
+    arrowheadColor: muted,
+    textColor: bodyText,
+    mainBkg: backgroundAlt,
+    nodeBkg: backgroundAlt,
+    nodeTextColor: bodyText,
+    clusterBkg: background,
+    clusterBorder: border,
+    edgeLabelBackground: backgroundAlt,
+    actorBkg: backgroundAlt,
+    actorBorder: main,
+    actorTextColor: bodyText,
+    actorLineColor: muted,
+    signalColor: bodyText,
+    signalTextColor: bodyText,
+    labelBoxBkgColor: backgroundAlt,
+    labelBoxBorderColor: border,
+    labelTextColor: bodyText,
+    loopTextColor: bodyText,
+    stateBkg: backgroundAlt,
+    stateLabelColor: bodyText,
+    transitionColor: muted,
+    transitionLabelColor: bodyText,
+    labelBackgroundColor: backgroundAlt,
+    compositeBackground: background,
+    compositeTitleBackground: backgroundAlt,
+    altBackground: background,
+    rowOdd: backgroundAlt,
+    rowEven: background,
+    attributeBackgroundColorOdd: backgroundAlt,
+    attributeBackgroundColorEven: background,
+    classText: bodyText,
+    noteBkgColor: backgroundAlt,
+    noteTextColor: bodyText,
+    noteBorderColor: border
   };
 }
 


### PR DESCRIPTION
## Summary

- move Mermaid container presentation from custom CSS to Tailwind utilities shared by Markdown and Org rendering
- retain only the SVG responsiveness rule that targets Mermaid's runtime-generated markup
- enable Mermaid's dark-mode color calculations and map theme palette colors across diagram-specific variables
- improve node text, edge labels, sequence lifelines, state transitions, notes, and ER attribute-row contrast

## Verification

- `nix develop -c make build`
- Hugo build for the multilingual demo
- Pagefind indexing for the demo
- generated markup checks for Markdown and Org Mermaid containers
- headless Chromium renders of flowchart, sequence, state, and ER diagrams
- visual inspection in both `clay` and `nord` dark palettes