### PR TITLE
fix(css): distinguish links in prose

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -281,12 +281,19 @@ h6 > span.tags {
   @apply hidden;
 }
 
-:where(.post-content, .prose) a {
-  @apply text-inherit no-underline;
+:is(.post-content, .prose) :where(a):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+  @apply text-[var(--color-main)] underline decoration-[0.08em]
+    underline-offset-[0.15em];
+  text-decoration-color: color-mix(in srgb, var(--color-main) 55%, transparent);
 }
 
-:where(.post-content, .prose) a:hover {
-  @apply text-[var(--color-main-light)];
+:is(.post-content, .prose) :where(a):not(:where([class~="not-prose"], [class~="not-prose"] *)):hover {
+  @apply text-[var(--color-main-light)] decoration-current;
+}
+
+:is(.post-content, .prose) :where(a):not(:where([class~="not-prose"], [class~="not-prose"] *)):focus-visible {
+  @apply rounded-[0.125rem] outline-2 outline-offset-2
+    outline-[var(--color-main-light)];
 }
 
 /* Code blocks */

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2081,12 +2081,26 @@ html {
 h1 > span.tags, h2 > span.tags, h3 > span.tags, h4 > span.tags, h5 > span.tags, h6 > span.tags {
   display: none;
 }
-:where(.post-content, .prose) a {
-  color: inherit;
-  text-decoration-line: none;
+:is(.post-content, .prose) :where(a):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+  color: var(--color-main);
+  text-decoration-line: underline;
+  text-decoration-thickness: 0.08em;
+  text-underline-offset: 0.15em;
+  text-decoration-color: color-mix(in srgb, #8c6056 55%, transparent);
+  @supports (color: color-mix(in lab, red, red)) {
+    text-decoration-color: color-mix(in srgb, var(--color-main) 55%, transparent);
+  }
 }
-:where(.post-content, .prose) a:hover {
+:is(.post-content, .prose) :where(a):not(:where([class~="not-prose"], [class~="not-prose"] *)):hover {
   color: var(--color-main-light);
+  text-decoration-color: currentcolor;
+}
+:is(.post-content, .prose) :where(a):not(:where([class~="not-prose"], [class~="not-prose"] *)):focus-visible {
+  border-radius: 0.125rem;
+  outline-style: var(--tw-outline-style);
+  outline-width: 2px;
+  outline-offset: 2px;
+  outline-color: var(--color-main-light);
 }
 :where(.post-content, .prose) pre:not(.mermaid) {
   overflow-x: auto;

--- a/demo/content/posts/markdown-guide.md
+++ b/demo/content/posts/markdown-guide.md
@@ -142,6 +142,8 @@ You can also use reference-style links:
 [reference]: https://example.com "Optional title"
 ```
 
+Rendered example: [Visit example.com](https://example.com) to see how links appear in body text.
+
 ### Images
 
 Images use similar syntax to links but start with an exclamation mark:

--- a/demo/content/posts/org-mode.org
+++ b/demo/content/posts/org-mode.org
@@ -37,7 +37,7 @@ The code block feature enables something called "literate programming" – you c
 
 ** Publishing and Sharing Your Work
 One of Org Mode's most impressive features is its export system. A single Org file can be transformed into HTML, PDF, LaTeX, slides, or numerous other formats. This means you can write once and publish anywhere, from academic papers to blog posts to presentation slides.
-The HTML export is particularly noteworthy. Many websites and blogs are generated directly from Org Mode files, allowing authors to maintain their content in a familiar, structured format while producing professional web output.
+The HTML export is particularly noteworthy. Many websites and blogs are generated directly from Org Mode files, allowing authors to maintain their content in a familiar, structured format while producing professional web output. The [[https://orgmode.org/][Org Mode website]] documents the available publishing workflows.
 
 ** The Learning Curve Reality
 Org Mode isn't without its challenges. It lives within Emacs, which itself has a steep learning curve. The keybindings are numerous, and the full feature set can be overwhelming. You'll likely spend time customizing and configuring to match your specific needs.


### PR DESCRIPTION
## Summary

- make ordinary links in rendered prose distinguishable without requiring hover
- use theme-aware link color, a subtle underline, and a stronger hover underline
- add a consistent `focus-visible` outline for keyboard navigation
- preserve component-specific styling for cards, pills, navigation, and `not-prose` regions
- add rendered link examples to both Markdown and Org demo content

## Verification

- `nix develop -c make css`
- `nix develop -c make build`
- multilingual demo Hugo production build
- Pagefind indexing for the demo site
- generated HTML checks for Markdown and Org links