### PR TITLE
fix(content): prevent large images from overflowing

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -255,7 +255,7 @@ html { scroll-behavior: smooth; }
 }
 
 .post-content img {
-  @apply block h-auto;
+  @apply block h-auto max-w-full;
 }
 
 .post-content table {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2055,6 +2055,7 @@ html {
 .post-content img {
   display: block;
   height: auto;
+  max-width: 100%;
 }
 .post-content table {
   width: 100%;


### PR DESCRIPTION
## Summary
- Constrain post content images to the available screen width so oversized images do not create horizontal scrolling on mobile.
- Regenerate the committed Tailwind output CSS.

## Testing
- `make css`
- `make build`
- `git diff --check`