### PR TITLE
chore(theme): add page intros and mobile UI polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,18 @@ It surfaces up to 3 projects whose frontmatter sets `featured: true`,
 and renders nothing if none match — so flipping the param on without
 any featured content is also safe.
 
+To add intro text to the projects index, create `content/projects/_index.md`.
+Use `description` for a short lead line and the page body for longer markdown:
+
+```markdown
+---
+title: "Projects"
+description: "Selected work across infrastructure, tools, and product systems."
+---
+
+Short intro copy can live here with normal Markdown formatting.
+```
+
 Frontmatter schema (all fields optional except `title` and `date`):
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -56,8 +56,10 @@ It surfaces up to 3 projects whose frontmatter sets `featured: true`,
 and renders nothing if none match — so flipping the param on without
 any featured content is also safe.
 
-To add intro text to the projects index, create `content/projects/_index.md`.
-Use `description` for a short lead line and the page body for longer markdown:
+To add intro text to top-level list pages such as `/projects/`, `/posts/`, or
+`/tags/`, create that page's `_index.md`; for the home page, use
+`content/_index.md`. Use `description` for a short lead line and the page body
+for longer markdown:
 
 ```markdown
 ---

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -691,6 +691,74 @@ h6 > span.tags {
     outline-none;
 }
 
+/* Bottom page actions: distinct mobile strip, compact fixed desktop links. */
+.page-actions {
+  @apply mx-auto mt-14 mb-6 max-w-[var(--max-width-content)] border-t
+    border-[var(--color-border)] px-3 pt-6 text-center text-sm;
+}
+
+.back-to-top-link {
+  @apply inline-flex cursor-pointer items-center justify-center rounded-md
+    bg-[var(--color-main)] px-6 py-2 text-sm font-semibold text-white
+    no-underline shadow-sm;
+}
+
+.back-to-top-link:hover,
+.back-to-top-link:focus-visible {
+  @apply bg-[var(--color-main-light)] text-white outline-none;
+}
+
+.post-nav-links {
+  @apply mt-3 flex flex-wrap justify-center gap-2;
+}
+
+.post-nav-link {
+  @apply min-w-32 flex-1 rounded-md border border-[var(--color-border)]
+    bg-[var(--color-background-alt)] px-3 py-2 text-sm font-semibold
+    text-[var(--color-main)] no-underline;
+}
+
+.post-nav-link:hover,
+.post-nav-link:focus-visible {
+  @apply border-[var(--color-main-light)] text-[var(--color-main-light)]
+    outline-none;
+}
+
+.pagination-status {
+  @apply mt-3 mb-0 text-sm text-[var(--color-muted-text)];
+}
+
+@media (min-width: 1024px) {
+  .page-actions {
+    @apply fixed right-2 bottom-2 m-0 max-w-none border-0 p-0 text-right;
+  }
+
+  .tag-page-actions {
+    @apply right-8 bottom-8;
+  }
+
+  .back-to-top-link {
+    @apply mb-1 px-2 py-1 text-sm font-normal shadow-none;
+  }
+
+  .post-nav-links {
+    @apply mt-2 block;
+  }
+
+  .post-nav-link {
+    @apply min-w-0 flex-none border-0 bg-transparent p-0 font-normal
+      text-inherit;
+  }
+
+  .post-nav-link + .post-nav-link {
+    @apply ml-2;
+  }
+
+  .pagination-status {
+    @apply mt-2;
+  }
+}
+
 /* ── Projects ─────────────────────────────────────────────────────────
    Case-study meta, status indicator, stack pills, cover image, grid
    listing, and the homepage featured-work block. */

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -710,6 +710,17 @@ h6 > span.tags {
 }
 
 /* Project listing grid. */
+.project-list-description {
+  margin: 0.25rem 0 0;
+  color: var(--color-muted-text);
+  font-size: 1.0625rem;
+  line-height: 1.6;
+}
+
+.project-list-intro {
+  margin-top: 0.75rem;
+}
+
 .project-grid {
   list-style: none;
   padding: 0;

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -709,18 +709,19 @@ h6 > span.tags {
   border: 1px solid var(--color-border);
 }
 
-/* Project listing grid. */
-.project-list-description {
+/* Optional lead text for home, section, taxonomy, and project index pages. */
+.page-intro-description {
   margin: 0.25rem 0 0;
   color: var(--color-muted-text);
   font-size: 1.0625rem;
   line-height: 1.6;
 }
 
-.project-list-intro {
+.page-intro-content {
   margin-top: 0.75rem;
 }
 
+/* Project listing grid. */
 .project-grid {
   list-style: none;
   padding: 0;

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -605,8 +605,8 @@ h6 > span.tags {
 
 /* Theme toggle button in the nav. */
 .theme-toggle {
-  @apply cursor-pointer border-0 bg-transparent px-[0.4rem] py-1
-    leading-none text-[var(--color-body-text)];
+  @apply inline-flex size-8 cursor-pointer items-center justify-center
+    border-0 bg-transparent leading-none text-[var(--color-body-text)];
 }
 
 .theme-toggle:hover {
@@ -621,7 +621,7 @@ h6 > span.tags {
 
 /* Mobile navigation menu. */
 .mobile-nav {
-  @apply relative ml-1;
+  @apply relative;
 }
 
 .mobile-nav-toggle {

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -605,16 +605,12 @@ h6 > span.tags {
 
 /* Theme toggle button in the nav. */
 .theme-toggle {
-  background: transparent;
-  border: 0;
-  padding: 0.25rem 0.4rem;
-  cursor: pointer;
-  color: var(--color-body-text);
-  line-height: 1;
+  @apply cursor-pointer border-0 bg-transparent px-[0.4rem] py-1
+    leading-none text-[var(--color-body-text)];
 }
 
 .theme-toggle:hover {
-  color: var(--color-neutral-accent);
+  @apply text-[var(--color-neutral-accent)];
 }
 
 .theme-toggle .icon-moon { display: inline; }
@@ -622,6 +618,78 @@ h6 > span.tags {
 
 [data-theme="dark"] .theme-toggle .icon-moon { display: none; }
 [data-theme="dark"] .theme-toggle .icon-sun  { display: inline; }
+
+/* Mobile navigation menu. */
+.mobile-nav {
+  @apply relative ml-1;
+}
+
+.mobile-nav-toggle {
+  @apply inline-flex size-8 cursor-pointer list-none items-center justify-center
+    rounded-md border border-[var(--color-border)]
+    bg-[var(--color-background-alt)] text-[var(--color-body-text)];
+}
+
+.mobile-nav-toggle::-webkit-details-marker {
+  display: none;
+}
+
+.mobile-nav-toggle:hover,
+.mobile-nav-toggle:focus-visible {
+  @apply border-[var(--color-main-light)] text-[var(--color-heading-text)]
+    outline-none;
+}
+
+.mobile-nav-icon,
+.mobile-nav-icon::before,
+.mobile-nav-icon::after {
+  @apply block h-0.5 w-4 rounded-full bg-current;
+}
+
+.mobile-nav-icon {
+  @apply relative;
+}
+
+.mobile-nav-icon::before,
+.mobile-nav-icon::after {
+  content: "";
+  @apply absolute left-0;
+}
+
+.mobile-nav-icon::before {
+  @apply top-[-0.35rem];
+}
+
+.mobile-nav-icon::after {
+  @apply top-[0.35rem];
+}
+
+.mobile-nav[open] .mobile-nav-panel {
+  @apply block;
+}
+
+.mobile-nav-panel {
+  @apply absolute right-0 z-30 mt-2 hidden min-w-48 rounded-lg
+    border border-[var(--color-border)] bg-[var(--color-background)]
+    p-[0.35rem] shadow-[0_0.75rem_2rem_rgb(0_0_0_/_0.12)];
+}
+
+.mobile-nav-section + .mobile-nav-section {
+  @apply mt-[0.35rem] border-t border-[var(--color-border)] pt-[0.35rem];
+}
+
+.mobile-nav-link {
+  @apply block rounded-[0.35rem] px-[0.65rem] py-[0.55rem]
+    text-sm font-bold leading-[1.2] text-[var(--color-muted-text)]
+    no-underline uppercase;
+}
+
+.mobile-nav-link:hover,
+.mobile-nav-link:focus-visible,
+.mobile-nav-link.is-active {
+  @apply bg-[var(--color-background-alt)] text-[var(--color-main)]
+    outline-none;
+}
 
 /* ── Projects ─────────────────────────────────────────────────────────
    Case-study meta, status indicator, stack pills, cover image, grid

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1161,6 +1161,31 @@ h6 > span.tags {
 }
 
 @media (max-width: 767px) {
+  .er-pagefind-search {
+    --pf-modal-max-height: calc(100dvh - 1rem);
+    --pf-modal-top: 0.5rem;
+  }
+
+  .er-pagefind-search dialog.pf-modal {
+    inset: 0.5rem !important;
+    width: auto !important;
+    height: auto !important;
+    max-height: calc(100dvh - 1rem) !important;
+    margin: 0 !important;
+    border-radius: 0.5rem !important;
+  }
+
+  .er-pagefind-search pagefind-modal-body,
+  .er-pagefind-search .pf-modal-body,
+  .er-pagefind-search .pf-results {
+    max-height: calc(100dvh - 4rem) !important;
+  }
+
+  .er-pagefind-search pagefind-modal-footer,
+  .er-pagefind-search .pf-modal-footer {
+    display: none !important;
+  }
+
   .er-pagefind-search .pf-trigger-shortcut {
     display: none !important;
   }

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1119,9 +1119,6 @@
   .ml-1 {
     margin-left: calc(var(--spacing) * 1);
   }
-  .ml-2 {
-    margin-left: calc(var(--spacing) * 2);
-  }
   .box-border {
     box-sizing: border-box;
   }
@@ -2366,12 +2363,15 @@ h1 > span.tags, h2 > span.tags, h3 > span.tags, h4 > span.tags, h5 > span.tags, 
   color: var(--color-body-text);
 }
 .theme-toggle {
+  display: inline-flex;
+  width: calc(var(--spacing) * 8);
+  height: calc(var(--spacing) * 8);
   cursor: pointer;
+  align-items: center;
+  justify-content: center;
   border-style: var(--tw-border-style);
   border-width: 0px;
   background-color: transparent;
-  padding-inline: 0.4rem;
-  padding-block: calc(var(--spacing) * 1);
   --tw-leading: 1;
   line-height: 1;
   color: var(--color-body-text);
@@ -2393,7 +2393,6 @@ h1 > span.tags, h2 > span.tags, h3 > span.tags, h4 > span.tags, h5 > span.tags, 
 }
 .mobile-nav {
   position: relative;
-  margin-left: calc(var(--spacing) * 1);
 }
 .mobile-nav-toggle {
   display: inline-flex;

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1578,6 +1578,11 @@
       display: flex;
     }
   }
+  .md\:hidden {
+    @media (width >= 48rem) {
+      display: none;
+    }
+  }
   .md\:items-center {
     @media (width >= 48rem) {
       align-items: center;
@@ -2361,12 +2366,15 @@ h1 > span.tags, h2 > span.tags, h3 > span.tags, h4 > span.tags, h5 > span.tags, 
   color: var(--color-body-text);
 }
 .theme-toggle {
-  background: transparent;
-  border: 0;
-  padding: 0.25rem 0.4rem;
   cursor: pointer;
-  color: var(--color-body-text);
+  border-style: var(--tw-border-style);
+  border-width: 0px;
+  background-color: transparent;
+  padding-inline: 0.4rem;
+  padding-block: calc(var(--spacing) * 1);
+  --tw-leading: 1;
   line-height: 1;
+  color: var(--color-body-text);
 }
 .theme-toggle:hover {
   color: var(--color-neutral-accent);
@@ -2382,6 +2390,102 @@ h1 > span.tags, h2 > span.tags, h3 > span.tags, h4 > span.tags, h5 > span.tags, 
 }
 [data-theme="dark"] .theme-toggle .icon-sun {
   display: inline;
+}
+.mobile-nav {
+  position: relative;
+  margin-left: calc(var(--spacing) * 1);
+}
+.mobile-nav-toggle {
+  display: inline-flex;
+  width: calc(var(--spacing) * 8);
+  height: calc(var(--spacing) * 8);
+  cursor: pointer;
+  list-style-type: none;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-md);
+  border-style: var(--tw-border-style);
+  border-width: 1px;
+  border-color: var(--color-border);
+  background-color: var(--color-background-alt);
+  color: var(--color-body-text);
+}
+.mobile-nav-toggle::-webkit-details-marker {
+  display: none;
+}
+.mobile-nav-toggle:hover, .mobile-nav-toggle:focus-visible {
+  border-color: var(--color-main-light);
+  color: var(--color-heading-text);
+  --tw-outline-style: none;
+  outline-style: none;
+}
+.mobile-nav-icon, .mobile-nav-icon::before, .mobile-nav-icon::after {
+  display: block;
+  height: calc(var(--spacing) * 0.5);
+  width: calc(var(--spacing) * 4);
+  border-radius: calc(infinity * 1px);
+  background-color: currentcolor;
+}
+.mobile-nav-icon {
+  position: relative;
+}
+.mobile-nav-icon::before, .mobile-nav-icon::after {
+  content: "";
+  position: absolute;
+  left: calc(var(--spacing) * 0);
+}
+.mobile-nav-icon::before {
+  top: -0.35rem;
+}
+.mobile-nav-icon::after {
+  top: 0.35rem;
+}
+.mobile-nav[open] .mobile-nav-panel {
+  display: block;
+}
+.mobile-nav-panel {
+  position: absolute;
+  right: calc(var(--spacing) * 0);
+  z-index: 30;
+  margin-top: calc(var(--spacing) * 2);
+  display: none;
+  min-width: calc(var(--spacing) * 48);
+  border-radius: var(--radius-lg);
+  border-style: var(--tw-border-style);
+  border-width: 1px;
+  border-color: var(--color-border);
+  background-color: var(--color-background);
+  padding: 0.35rem;
+  --tw-shadow: 0 0.75rem 2rem var(--tw-shadow-color, rgb(0 0 0 / 0.12));
+  box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+}
+.mobile-nav-section + .mobile-nav-section {
+  margin-top: 0.35rem;
+  border-top-style: var(--tw-border-style);
+  border-top-width: 1px;
+  border-color: var(--color-border);
+  padding-top: 0.35rem;
+}
+.mobile-nav-link {
+  display: block;
+  border-radius: 0.35rem;
+  padding-inline: 0.65rem;
+  padding-block: 0.55rem;
+  font-size: var(--text-sm);
+  line-height: var(--tw-leading, var(--text-sm--line-height));
+  --tw-leading: 1.2;
+  line-height: 1.2;
+  --tw-font-weight: var(--font-weight-bold);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-muted-text);
+  text-transform: uppercase;
+  text-decoration-line: none;
+}
+.mobile-nav-link:hover, .mobile-nav-link:focus-visible, .mobile-nav-link.is-active {
+  background-color: var(--color-background-alt);
+  color: var(--color-main);
+  --tw-outline-style: none;
+  outline-style: none;
 }
 .status-dot {
   display: inline-block;

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -26,6 +26,7 @@
     --text-3xl--line-height: calc(2.25 / 1.875);
     --text-4xl: 2.25rem;
     --text-4xl--line-height: calc(2.5 / 2.25);
+    --font-weight-normal: 400;
     --font-weight-semibold: 600;
     --font-weight-bold: 700;
     --tracking-wide: 0.025em;
@@ -1095,9 +1096,6 @@
   .mt-10 {
     margin-top: calc(var(--spacing) * 10);
   }
-  .mb-0 {
-    margin-bottom: calc(var(--spacing) * 0);
-  }
   .mb-1 {
     margin-bottom: calc(var(--spacing) * 1);
   }
@@ -1142,6 +1140,9 @@
   }
   .inline-block {
     display: inline-block;
+  }
+  .inline-flex {
+    display: inline-flex;
   }
   .table {
     display: table;
@@ -1594,31 +1595,6 @@
       }
     }
   }
-  .lg\:fixed {
-    @media (width >= 64rem) {
-      position: fixed;
-    }
-  }
-  .lg\:right-2 {
-    @media (width >= 64rem) {
-      right: calc(var(--spacing) * 2);
-    }
-  }
-  .lg\:right-8 {
-    @media (width >= 64rem) {
-      right: calc(var(--spacing) * 8);
-    }
-  }
-  .lg\:bottom-2 {
-    @media (width >= 64rem) {
-      bottom: calc(var(--spacing) * 2);
-    }
-  }
-  .lg\:bottom-8 {
-    @media (width >= 64rem) {
-      bottom: calc(var(--spacing) * 8);
-    }
-  }
   .lg\:prose-lg {
     @media (width >= 64rem) {
       font-size: 1.125rem;
@@ -1825,11 +1801,6 @@
       margin-top: calc(var(--spacing) * 10);
     }
   }
-  .lg\:mb-0 {
-    @media (width >= 64rem) {
-      margin-bottom: calc(var(--spacing) * 0);
-    }
-  }
   .lg\:block {
     @media (width >= 64rem) {
       display: block;
@@ -1853,11 +1824,6 @@
   .lg\:text-left {
     @media (width >= 64rem) {
       text-align: left;
-    }
-  }
-  .lg\:text-right {
-    @media (width >= 64rem) {
-      text-align: right;
     }
   }
 }
@@ -2485,6 +2451,130 @@ h1 > span.tags, h2 > span.tags, h3 > span.tags, h4 > span.tags, h5 > span.tags, 
   color: var(--color-main);
   --tw-outline-style: none;
   outline-style: none;
+}
+.page-actions {
+  margin-inline: auto;
+  margin-top: calc(var(--spacing) * 14);
+  margin-bottom: calc(var(--spacing) * 6);
+  max-width: var(--max-width-content);
+  border-top-style: var(--tw-border-style);
+  border-top-width: 1px;
+  border-color: var(--color-border);
+  padding-inline: calc(var(--spacing) * 3);
+  padding-top: calc(var(--spacing) * 6);
+  text-align: center;
+  font-size: var(--text-sm);
+  line-height: var(--tw-leading, var(--text-sm--line-height));
+}
+.back-to-top-link {
+  display: inline-flex;
+  cursor: pointer;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-md);
+  background-color: var(--color-main);
+  padding-inline: calc(var(--spacing) * 6);
+  padding-block: calc(var(--spacing) * 2);
+  font-size: var(--text-sm);
+  line-height: var(--tw-leading, var(--text-sm--line-height));
+  --tw-font-weight: var(--font-weight-semibold);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-white);
+  text-decoration-line: none;
+  --tw-shadow: 0 1px 3px 0 var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 1px 2px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
+  box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+}
+.back-to-top-link:hover, .back-to-top-link:focus-visible {
+  background-color: var(--color-main-light);
+  color: var(--color-white);
+  --tw-outline-style: none;
+  outline-style: none;
+}
+.post-nav-links {
+  margin-top: calc(var(--spacing) * 3);
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: calc(var(--spacing) * 2);
+}
+.post-nav-link {
+  min-width: calc(var(--spacing) * 32);
+  flex: 1;
+  border-radius: var(--radius-md);
+  border-style: var(--tw-border-style);
+  border-width: 1px;
+  border-color: var(--color-border);
+  background-color: var(--color-background-alt);
+  padding-inline: calc(var(--spacing) * 3);
+  padding-block: calc(var(--spacing) * 2);
+  font-size: var(--text-sm);
+  line-height: var(--tw-leading, var(--text-sm--line-height));
+  --tw-font-weight: var(--font-weight-semibold);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-main);
+  text-decoration-line: none;
+}
+.post-nav-link:hover, .post-nav-link:focus-visible {
+  border-color: var(--color-main-light);
+  color: var(--color-main-light);
+  --tw-outline-style: none;
+  outline-style: none;
+}
+.pagination-status {
+  margin-top: calc(var(--spacing) * 3);
+  margin-bottom: calc(var(--spacing) * 0);
+  font-size: var(--text-sm);
+  line-height: var(--tw-leading, var(--text-sm--line-height));
+  color: var(--color-muted-text);
+}
+@media (min-width: 1024px) {
+  .page-actions {
+    position: fixed;
+    right: calc(var(--spacing) * 2);
+    bottom: calc(var(--spacing) * 2);
+    margin: calc(var(--spacing) * 0);
+    max-width: none;
+    border-style: var(--tw-border-style);
+    border-width: 0px;
+    padding: calc(var(--spacing) * 0);
+    text-align: right;
+  }
+  .tag-page-actions {
+    right: calc(var(--spacing) * 8);
+    bottom: calc(var(--spacing) * 8);
+  }
+  .back-to-top-link {
+    margin-bottom: calc(var(--spacing) * 1);
+    padding-inline: calc(var(--spacing) * 2);
+    padding-block: calc(var(--spacing) * 1);
+    font-size: var(--text-sm);
+    line-height: var(--tw-leading, var(--text-sm--line-height));
+    --tw-font-weight: var(--font-weight-normal);
+    font-weight: var(--font-weight-normal);
+    --tw-shadow: 0 0 #0000;
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .post-nav-links {
+    margin-top: calc(var(--spacing) * 2);
+    display: block;
+  }
+  .post-nav-link {
+    min-width: calc(var(--spacing) * 0);
+    flex: none;
+    border-style: var(--tw-border-style);
+    border-width: 0px;
+    background-color: transparent;
+    padding: calc(var(--spacing) * 0);
+    --tw-font-weight: var(--font-weight-normal);
+    font-weight: var(--font-weight-normal);
+    color: inherit;
+  }
+  .post-nav-link + .post-nav-link {
+    margin-left: calc(var(--spacing) * 2);
+  }
+  .pagination-status {
+    margin-top: calc(var(--spacing) * 2);
+  }
 }
 .status-dot {
   display: inline-block;

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2902,6 +2902,24 @@ h1 > span.tags, h2 > span.tags, h3 > span.tags, h4 > span.tags, h5 > span.tags, 
   color: var(--color-neutral-accent) !important;
 }
 @media (max-width: 767px) {
+  .er-pagefind-search {
+    --pf-modal-max-height: calc(100dvh - 1rem);
+    --pf-modal-top: 0.5rem;
+  }
+  .er-pagefind-search dialog.pf-modal {
+    inset: 0.5rem !important;
+    width: auto !important;
+    height: auto !important;
+    max-height: calc(100dvh - 1rem) !important;
+    margin: 0 !important;
+    border-radius: 0.5rem !important;
+  }
+  .er-pagefind-search pagefind-modal-body, .er-pagefind-search .pf-modal-body, .er-pagefind-search .pf-results {
+    max-height: calc(100dvh - 4rem) !important;
+  }
+  .er-pagefind-search pagefind-modal-footer, .er-pagefind-search .pf-modal-footer {
+    display: none !important;
+  }
   .er-pagefind-search .pf-trigger-shortcut {
     display: none !important;
   }

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2470,6 +2470,15 @@ h1 > span.tags, h2 > span.tags, h3 > span.tags, h4 > span.tags, h5 > span.tags, 
   border-radius: 0.375rem;
   border: 1px solid var(--color-border);
 }
+.project-list-description {
+  margin: 0.25rem 0 0;
+  color: var(--color-muted-text);
+  font-size: 1.0625rem;
+  line-height: 1.6;
+}
+.project-list-intro {
+  margin-top: 0.75rem;
+}
 .project-grid {
   list-style: none;
   padding: 0;

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2470,13 +2470,13 @@ h1 > span.tags, h2 > span.tags, h3 > span.tags, h4 > span.tags, h5 > span.tags, 
   border-radius: 0.375rem;
   border: 1px solid var(--color-border);
 }
-.project-list-description {
+.page-intro-description {
   margin: 0.25rem 0 0;
   color: var(--color-muted-text);
   font-size: 1.0625rem;
   line-height: 1.6;
 }
-.project-list-intro {
+.page-intro-content {
   margin-top: 0.75rem;
 }
 .project-grid {

--- a/demo/content/_index.md
+++ b/demo/content/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Er Demo"
+description: "A compact Hugo theme for writing, notes, and project portfolios."
+---
+
+This demo shows the theme's main writing, search, and project layouts.

--- a/demo/content/categories/_index.md
+++ b/demo/content/categories/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Categories"
+description: "Grouped views of the main writing archive."
+---
+
+Categories collect broader areas of work than individual tags.

--- a/demo/content/posts/_index.md
+++ b/demo/content/posts/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Posts"
+description: "Notes on systems, programming languages, and durable tools."
+---
+
+Longer essays and shorter technical notes, collected by date.

--- a/demo/content/projects/_index.md
+++ b/demo/content/projects/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Projects"
+description: "Selected work across infrastructure, developer tooling, and product systems."
+---
+
+These case studies show the context, constraints, and tradeoffs behind each project.

--- a/demo/content/stacks/_index.md
+++ b/demo/content/stacks/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Stacks"
+description: "Technologies and tools used across project case studies."
+---
+
+Each stack page links to the projects and writing that mention it.

--- a/demo/content/tags/_index.md
+++ b/demo/content/tags/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Tags"
+description: "Browse writing by topic."
+---
+
+Use tags to move across related posts, projects, and examples.

--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -4,6 +4,8 @@ searchPlaceholder:
   other: Suchen...
 languageSwitcher:
   other: Sprachen
+menu:
+  other: Menue
 tags:
   other: Schlagworte
 categories:

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -4,6 +4,8 @@ searchPlaceholder:
   other: Search...
 languageSwitcher:
   other: Languages
+menu:
+  other: Menu
 tags:
   other: tags
 categories:

--- a/i18n/ja.yaml
+++ b/i18n/ja.yaml
@@ -4,6 +4,8 @@ searchPlaceholder:
   other: 検索...
 languageSwitcher:
   other: 言語
+menu:
+  other: メニュー
 tags:
   other: タグ
 categories:

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -11,7 +11,7 @@
     {{ end }}
   </ul>
 </main>
-<div class="text-center block lg:fixed lg:bottom-2 lg:right-2 mb-3 lg:mb-0" data-pagefind-ignore>
+<div class="page-actions" data-pagefind-ignore>
 {{ partial "back-to-top.html" . }}
 </div>
 {{ end }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
 <main class="content-shell my-4 px-3">
   <h1 class="text-2xl font-semibold font-sans mb-3">{{ .Title }}</h1>
-  {{ .Content }}
+  {{ partial "page-intro.html" . }}
   <ul class="list-none">
     {{ range .Data.Pages }}
       <li class="leading-normal flex justify-between space-y-1">

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -43,11 +43,11 @@
   {{ end }}
 </main>
 
-<div class="text-center lg:text-right block lg:fixed lg:bottom-2 lg:right-2 mb-3 lg:mb-0" data-pagefind-ignore>
-  {{ partial "back-to-top.html" . }}<br>
-  <p class="mb-0 mt-2">
-  {{ with .PrevInSection }}{{ if . }}<a href="{{ .RelPermalink }}">{{ T "prevPost" }}</a>{{ end }}{{ end }}
-  {{ with .NextInSection }}{{ if . }}<a href="{{ .RelPermalink }}">{{ T "nextPost" }}</a>{{ end }}{{ end }}
-  </p>
+<div class="page-actions" data-pagefind-ignore>
+  {{ partial "back-to-top.html" . }}
+  <nav class="post-nav-links" aria-label="Post navigation">
+  {{ with .PrevInSection }}{{ if . }}<a class="post-nav-link" href="{{ .RelPermalink }}">{{ T "prevPost" }}</a>{{ end }}{{ end }}
+  {{ with .NextInSection }}{{ if . }}<a class="post-nav-link" href="{{ .RelPermalink }}">{{ T "nextPost" }}</a>{{ end }}{{ end }}
+  </nav>
 </div>
 {{ end }}

--- a/layouts/_default/tag.html
+++ b/layouts/_default/tag.html
@@ -13,7 +13,7 @@
     {{ end }}
   </ul>
 </main>
-<div class="text-center block lg:fixed lg:bottom-8 lg:right-8 mb-4 lg:mb-0" data-pagefind-ignore>
+<div class="page-actions tag-page-actions" data-pagefind-ignore>
 {{ partial "back-to-top.html" . }}
 </div>
 {{ end }}

--- a/layouts/_default/tag.html
+++ b/layouts/_default/tag.html
@@ -3,7 +3,7 @@
   <h1 class="text-3xl font-semibold font-sans mb-5">
     <span class="text-faint">#</span> {{ .Data.Term }}
   </h1>
-  {{ .Content }}
+  {{ partial "page-intro.html" . }}
   <ul class="list-none">
     {{ range .Data.Pages }}
       <li class="leading-relaxed flex justify-between">

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -13,7 +13,7 @@
     {{ end }}
   </ul>
 </main>
-<div class="text-center block lg:fixed lg:bottom-2 lg:right-2 mb-3 lg:mb-0" data-pagefind-ignore>
+<div class="page-actions" data-pagefind-ignore>
 {{ partial "back-to-top.html" . }}
 </div>
 {{ end }}

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -2,7 +2,7 @@
 <main class="content-shell my-4">
   {{ $type := .Type }}
   <h1 class="text-2xl font-semibold font-sans">{{ .Title }}</h1>
-  {{ .Content }}
+  {{ partial "page-intro.html" . }}
   <ul class="list-none p-0">
     {{ range $key, $value := .Data.Terms }}
       <li class="leading-normal inline-block bg-[var(--color-background-alt)] px-1 m-1">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,6 +1,7 @@
 {{ define "main" }}
 {{ $paginator := .Paginate (where .Site.RegularPages "Type" "in" .Site.Params.mainSections) }}
 <main class="content-shell my-4">
+  {{ partial "page-intro.html" . }}
   {{ partial "featured-projects.html" . }}
 
   <ul class="list-none p-0">

--- a/layouts/partials/back-to-top.html
+++ b/layouts/partials/back-to-top.html
@@ -2,7 +2,7 @@
 <span class="text-white hover:opacity-80 hover:text-white" data-pagefind-ignore>
   <a
     id="scroll-to-top"
-    class="text-sm opacity-0 rounded px-2 py-1 mb-1 bg-[var(--color-main)] cursor-pointer"
+    class="back-to-top-link opacity-0"
     onclick="topFunction()"
     style="visibility: hidden; display: none; transition: opacity .5s, visibility .5s;"
     title="back to top"

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -1,3 +1,4 @@
+{{- $mainMenu := .Site.Menus.main -}}
 <nav class="flex justify-between box-border p-3 pl-3 lg:pl-3 pr-2 lg:pr-2 mt-1 md:mt-0" id="navbar" data-pagefind-ignore>
   <div class="flex space-x-5">
     <span class="text-white">
@@ -11,7 +12,7 @@
       </a>
     </span>
 
-    {{ with .Site.Menus.main }}
+    {{ with $mainMenu }}
     <div class="hidden md:flex md:space-x-3 mt-2 md:mt-0 py-1 font-bold">
       {{ range . }}
       {{- $url := .URL -}}
@@ -40,5 +41,37 @@
       <span class="icon-moon" aria-hidden="true">&#9789;</span>
       <span class="icon-sun"  aria-hidden="true">&#9728;</span>
     </button>
+    {{ if or $mainMenu (gt (len hugo.Sites) 1) }}
+    <details class="mobile-nav md:hidden">
+      <summary class="mobile-nav-toggle" aria-label="{{ T "menu" | default "Menu" }}">
+        <span class="mobile-nav-icon" aria-hidden="true"></span>
+      </summary>
+      <div class="mobile-nav-panel">
+        {{ with $mainMenu }}
+        <div class="mobile-nav-section">
+          {{ range . }}
+          {{- $url := .URL -}}
+          {{- if .Page -}}
+            {{- $url = .Page.RelPermalink -}}
+          {{- else if not (or (strings.HasPrefix .URL "http://") (strings.HasPrefix .URL "https://") (strings.HasPrefix .URL "#")) -}}
+            {{- $url = .URL | relLangURL -}}
+          {{- end -}}
+          <a class="mobile-nav-link" href='{{ $url }}' title="{{ .Name }}">{{ if .Identifier }}{{ or (T .Identifier) .Name }}{{ else }}{{ .Name }}{{ end }}</a>
+          {{ end }}
+        </div>
+        {{ end }}
+        {{ if gt (len hugo.Sites) 1 }}
+        <div class="mobile-nav-section mobile-nav-languages" aria-label="{{ T "languageSwitcher" }}">
+          {{ range hugo.Sites }}
+          {{ $translation := where $.AllTranslations "Lang" .Language.Lang }}
+          {{ $href := .Home.RelPermalink }}
+          {{ with index $translation 0 }}{{ $href = .RelPermalink }}{{ end }}
+          <a class="mobile-nav-link {{ if eq $.Site.Language.Lang .Language.Lang }}is-active{{ end }}" href="{{ $href }}" hreflang="{{ .Language.Lang }}" lang="{{ .Language.Lang }}"{{ if eq $.Site.Language.Lang .Language.Lang }} aria-current="true"{{ end }}>{{ .Language.Label | default .Language.Lang }}</a>
+          {{ end }}
+        </div>
+        {{ end }}
+      </div>
+    </details>
+    {{ end }}
   </div>
 </nav>

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -27,14 +27,14 @@
     {{ end }}
   </div>
 
-  <div class="flex items-start md:items-center">
+  <div class="flex items-start gap-1 md:items-center">
     {{ if eq .Site.Params.search true }}
     {{ partial "search.html" . }}
     {{ end }}
     {{ partial "language-switcher.html" . }}
     <button
       type="button"
-      class="theme-toggle ml-2"
+      class="theme-toggle"
       aria-label="Toggle color theme"
       onclick="toggleTheme()"
     >

--- a/layouts/partials/page-intro.html
+++ b/layouts/partials/page-intro.html
@@ -1,0 +1,2 @@
+{{ with .Description }}<p class="page-intro-description">{{ . }}</p>{{ end }}
+{{ with .Content }}<div class="prose page-intro-content">{{ . }}</div>{{ end }}

--- a/layouts/partials/pagination.html
+++ b/layouts/partials/pagination.html
@@ -1,9 +1,10 @@
 {{ if gt .Paginator.TotalPages 1 }}
-<div class="text-center block lg:fixed lg:bottom-2 lg:right-2 mb-3 lg:mb-0" data-pagefind-ignore>
-{{ partial "back-to-top.html" . }}<br>
-<p class="mb-0 mt-2">{{ T "page" }} {{ .Paginator.PageNumber }} {{ T "of" }} {{ .Paginator.TotalPages }} <br>
-  {{ if .Paginator.HasNext }}<a href="{{ .Paginator.Next.URL | relURL }}" class="no-underline text-inherit hover:text-[var(--color-main-light)]">{{ T "olderPosts" }}</a>{{ end }}
-  {{ if .Paginator.HasPrev }}<a href="{{ .Paginator.Prev.URL | relURL }}" class="no-underline text-inherit hover:text-[var(--color-main-light)]">{{ T "newerPosts" }}</a>{{ end }}
-</p>
+<div class="page-actions pagination-actions" data-pagefind-ignore>
+{{ partial "back-to-top.html" . }}
+<p class="pagination-status">{{ T "page" }} {{ .Paginator.PageNumber }} {{ T "of" }} {{ .Paginator.TotalPages }}</p>
+<nav class="post-nav-links" aria-label="Pagination">
+  {{ if .Paginator.HasNext }}<a href="{{ .Paginator.Next.URL | relURL }}" class="post-nav-link">{{ T "olderPosts" }}</a>{{ end }}
+  {{ if .Paginator.HasPrev }}<a href="{{ .Paginator.Prev.URL | relURL }}" class="post-nav-link">{{ T "newerPosts" }}</a>{{ end }}
+</nav>
 </div>
 {{ end }}

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -1,5 +1,30 @@
 <script defer src="{{ "js/code-copy.js" | absURL }}"></script>
 
+<script type="text/javascript">
+document.addEventListener('DOMContentLoaded', function() {
+  var mobileNav = document.querySelector('.mobile-nav');
+  if (!mobileNav) return;
+
+  document.addEventListener('pointerdown', function(event) {
+    if (mobileNav.open && !mobileNav.contains(event.target)) {
+      mobileNav.open = false;
+    }
+  });
+
+  document.addEventListener('focusin', function(event) {
+    if (mobileNav.open && !mobileNav.contains(event.target)) {
+      mobileNav.open = false;
+    }
+  });
+
+  document.addEventListener('keydown', function(event) {
+    if (event.key === 'Escape') {
+      mobileNav.open = false;
+    }
+  });
+});
+</script>
+
 {{ if or (.Site.Params.showTagCloud | default true) (.Site.Params.showScrollToTop | default true) }}
 <script type="text/javascript">
 var prevScrollpos = window.pageYOffset;

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -45,7 +45,7 @@ window.onscroll = function() {
 
   {{ if .Site.Params.showScrollToTop | default true }}
   if (document.body.scrollTop > 1000 || document.documentElement.scrollTop > 1000) {
-      document.getElementById("scroll-to-top").style.display = "inline";
+      document.getElementById("scroll-to-top").style.display = "inline-flex";
       document.getElementById("scroll-to-top").style.visibility = "visible";
       document.getElementById("scroll-to-top").style.opacity = "1";
   } else {

--- a/layouts/projects/list.html
+++ b/layouts/projects/list.html
@@ -2,7 +2,8 @@
 <main class="post-main mx-auto my-4 px-3 lg:px-0">
   <header class="post-header">
     <h1 class="text-3xl font-semibold text-[var(--color-heading-text)] font-sans mb-2">{{ .Title }}</h1>
-    {{ with .Content }}<div class="prose">{{ . }}</div>{{ end }}
+    {{ with .Description }}<p class="project-list-description">{{ . }}</p>{{ end }}
+    {{ with .Content }}<div class="prose project-list-intro">{{ . }}</div>{{ end }}
   </header>
 
   <ul class="project-grid">

--- a/layouts/projects/list.html
+++ b/layouts/projects/list.html
@@ -2,8 +2,7 @@
 <main class="post-main mx-auto my-4 px-3 lg:px-0">
   <header class="post-header">
     <h1 class="text-3xl font-semibold text-[var(--color-heading-text)] font-sans mb-2">{{ .Title }}</h1>
-    {{ with .Description }}<p class="project-list-description">{{ . }}</p>{{ end }}
-    {{ with .Content }}<div class="prose project-list-intro">{{ . }}</div>{{ end }}
+    {{ partial "page-intro.html" . }}
   </header>
 
   <ul class="project-grid">

--- a/layouts/projects/single.html
+++ b/layouts/projects/single.html
@@ -59,11 +59,11 @@
   <div class="leading-normal prose lg:prose-lg post-content max-w-none">{{ .Content }}</div>
 </main>
 
-<div class="text-center lg:text-right block lg:fixed lg:bottom-2 lg:right-2 mb-3 lg:mb-0" data-pagefind-ignore>
-  {{ partial "back-to-top.html" . }}<br>
-  <p class="mb-0 mt-2">
-  {{ with .PrevInSection }}{{ if . }}<a href="{{ .RelPermalink }}">{{ T "prevPost" }}</a>{{ end }}{{ end }}
-  {{ with .NextInSection }}{{ if . }}<a href="{{ .RelPermalink }}">{{ T "nextPost" }}</a>{{ end }}{{ end }}
-  </p>
+<div class="page-actions" data-pagefind-ignore>
+  {{ partial "back-to-top.html" . }}
+  <nav class="post-nav-links" aria-label="Project navigation">
+  {{ with .PrevInSection }}{{ if . }}<a class="post-nav-link" href="{{ .RelPermalink }}">{{ T "prevPost" }}</a>{{ end }}{{ end }}
+  {{ with .NextInSection }}{{ if . }}<a class="post-nav-link" href="{{ .RelPermalink }}">{{ T "nextPost" }}</a>{{ end }}{{ end }}
+  </nav>
 </div>
 {{ end }}


### PR DESCRIPTION
## Summary
- Add reusable intro rendering for top-level list pages, including projects, posts, taxonomies, and the home page.
- Add demo `_index.md` content and README guidance for list-page descriptions.
- Add a mobile hamburger menu with localized labels, language links, and outside-click/Escape close behavior.
- Improve mobile layout for the theme toggle, search modal, and bottom page actions such as back-to-top and previous/next links.

## Testing
- `make build`
- `nix develop .. -c hugo -b http://example.test`
- `nix develop .. -c pagefind --site public`
- `git diff --check`