### PR TITLE
chore(projects): use tags and status-aware sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ date: 2025-03-12
 role:     "Lead engineer"
 client:   "Acme Co"            # omit for personal work
 period:   "2024 – 2025"
-stack:    [go, postgres, terraform]
+stacks:   [go, postgres, terraform]
 
 repo:     "https://github.com/you/acme"
 live_url: "https://acme.example"
@@ -99,8 +99,16 @@ Helpful shortcodes inside a project page:
 - `{{< results >}} ... {{< /results >}}` — metric strip at the top of
   a case study.
 
-Stacks are a real Hugo taxonomy, so `/stacks/rust/` etc. work out of
-the box.
+Stacks are rendered as a Hugo taxonomy using the `stacks` front matter
+key. If your site config declares custom `taxonomies`, keep the theme's
+stack taxonomy alongside Hugo's defaults:
+
+```yaml
+taxonomies:
+  category: categories
+  tag: tags
+  stack: stacks
+```
 
 ### Color palette
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ date: 2025-03-12
 role:     "Lead engineer"
 client:   "Acme Co"            # omit for personal work
 period:   "2024 – 2025"
-stacks:   [go, postgres, terraform]
+tags:     [go, postgres, terraform]
 
 repo:     "https://github.com/you/acme"
 live_url: "https://acme.example"
@@ -99,16 +99,8 @@ Helpful shortcodes inside a project page:
 - `{{< results >}} ... {{< /results >}}` — metric strip at the top of
   a case study.
 
-Stacks are rendered as a Hugo taxonomy using the `stacks` front matter
-key. If your site config declares custom `taxonomies`, keep the theme's
-stack taxonomy alongside Hugo's defaults:
-
-```yaml
-taxonomies:
-  category: categories
-  tag: tags
-  stack: stacks
-```
+Project stack pills use Hugo's default `tags` taxonomy, so terms like
+`go` and `postgres` link to `/tags/go/` and `/tags/postgres/`.
 
 ### Color palette
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ tags:     [go, postgres, terraform]
 repo:     "https://github.com/you/acme"
 live_url: "https://acme.example"
 
-status:   "shipped"            # shipped | wip | archived
+status:   "shipped"            # shipped | active | wip | archived | closed
 cover:    "cover.jpg"          # relative to the page bundle
 summary:  "Rebuilt the order pipeline; cut p99 latency by 38%."
 

--- a/archetypes/projects.md
+++ b/archetypes/projects.md
@@ -7,7 +7,7 @@ draft: true
 role:        ""           # e.g. "Lead engineer"
 client:      ""           # e.g. "Acme Co" — omit for personal work
 period:      ""           # e.g. "2024 – 2025"
-stack:       []           # e.g. [go, postgres, terraform]
+stacks:      []           # e.g. [go, postgres, terraform]
 
 # Links — both optional; rendered as icon badges when set.
 repo:        ""           # https://github.com/...

--- a/archetypes/projects.md
+++ b/archetypes/projects.md
@@ -13,7 +13,7 @@ tags:        []           # e.g. [go, postgres, terraform]
 repo:        ""           # https://github.com/...
 live_url:    ""           # https://...
 
-# Status drives the dot indicator: shipped | wip | archived.
+# Status drives the dot indicator: shipped | active | wip | archived | closed.
 status:      "shipped"
 
 # Cover image (relative to the page bundle or static path) and one-line

--- a/archetypes/projects.md
+++ b/archetypes/projects.md
@@ -7,7 +7,7 @@ draft: true
 role:        ""           # e.g. "Lead engineer"
 client:      ""           # e.g. "Acme Co" — omit for personal work
 period:      ""           # e.g. "2024 – 2025"
-stacks:      []           # e.g. [go, postgres, terraform]
+tags:        []           # e.g. [go, postgres, terraform]
 
 # Links — both optional; rendered as icon badges when set.
 repo:        ""           # https://github.com/...

--- a/config/_default/hugo.yaml
+++ b/config/_default/hugo.yaml
@@ -8,7 +8,6 @@ sectionPagesMenu: main
 taxonomies:
   category: categories
   tag: tags
-  stack: stacks
 
 related:
   includeNewer: true

--- a/demo/content/projects/edge-observatory.md
+++ b/demo/content/projects/edge-observatory.md
@@ -1,0 +1,18 @@
+---
+title: "Edge Observatory"
+date: 2024-07-22
+role: "Platform engineer"
+period: "2024"
+tags: [go, prometheus, grafana, edge]
+repo: "https://github.com/example/edge-observatory"
+status: shipped
+summary: "Regional telemetry for edge workers, with latency heatmaps and alert routes for local incidents."
+---
+
+Edge Observatory focused on making regional failures easier to see
+before global aggregates flattened the signal.
+
+## Outcome
+
+On-call engineers could compare regions, isolate local regressions, and
+route follow-up work to the owning deployment lane.

--- a/demo/content/projects/launch-ledger.md
+++ b/demo/content/projects/launch-ledger.md
@@ -1,0 +1,21 @@
+---
+title: "Launch Ledger"
+date: 2025-11-18
+role: "Staff engineer"
+client: "Northstar Labs"
+period: "2025"
+tags: [typescript, analytics, postgres, product]
+repo: "https://github.com/example/launch-ledger"
+live_url: "https://ledger.example"
+status: active
+summary: "A release-readiness dashboard that tied product signals, deploy health, and launch checklists into one view."
+featured: true
+---
+
+Launch Ledger brought launch notes, metrics, and rollout state into a
+single operational surface for product and engineering leads.
+
+## Outcome
+
+The team replaced a spreadsheet-heavy launch process with a dashboard
+that made owner, status, and risk visible before release day.

--- a/demo/content/projects/lisp-machine-emu.org
+++ b/demo/content/projects/lisp-machine-emu.org
@@ -2,7 +2,7 @@
 #+DATE: <2022-08-14 Sun>
 #+ROLE: Solo
 #+PERIOD: 2021 – 2022
-#+STACK[]: common-lisp sbcl docker
+#+STACKS[]: common-lisp sbcl docker
 #+REPO: https://github.com/example/lisp-machine-emu
 #+STATUS: archived
 #+SUMMARY: A weekend-project emulator for early-80s Lisp Machine instructions; usable but unmaintained.

--- a/demo/content/projects/lisp-machine-emu.org
+++ b/demo/content/projects/lisp-machine-emu.org
@@ -2,11 +2,10 @@
 #+DATE: <2022-08-14 Sun>
 #+ROLE: Solo
 #+PERIOD: 2021 – 2022
-#+STACKS[]: common-lisp sbcl docker
 #+REPO: https://github.com/example/lisp-machine-emu
 #+STATUS: archived
 #+SUMMARY: A weekend-project emulator for early-80s Lisp Machine instructions; usable but unmaintained.
-#+TAGS[]: emulators lisp retrocomputing
+#+TAGS[]: common-lisp sbcl docker emulators lisp retrocomputing
 
 * Overview
 

--- a/demo/content/projects/notes-cli.md
+++ b/demo/content/projects/notes-cli.md
@@ -3,7 +3,7 @@ title: "notes-cli"
 date: 2025-09-04
 role: "Solo"
 period: "2025 –"
-stacks: [rust, sqlite]
+tags: [rust, sqlite]
 repo: "https://github.com/example/notes-cli"
 status: wip
 summary: "Local-first plain-text notes CLI with full-text search and tagging."

--- a/demo/content/projects/notes-cli.md
+++ b/demo/content/projects/notes-cli.md
@@ -3,7 +3,7 @@ title: "notes-cli"
 date: 2025-09-04
 role: "Solo"
 period: "2025 –"
-stack: [rust, sqlite]
+stacks: [rust, sqlite]
 repo: "https://github.com/example/notes-cli"
 status: wip
 summary: "Local-first plain-text notes CLI with full-text search and tagging."

--- a/demo/content/projects/pasta-pipeline/index.md
+++ b/demo/content/projects/pasta-pipeline/index.md
@@ -4,14 +4,13 @@ date: 2025-03-12
 role: "Lead engineer"
 client: "Trattoria della Nonna"
 period: "2024 – 2025"
-stacks: [go, postgres, terraform, kafka]
 repo: "https://github.com/example/pasta-pipeline"
 live_url: "https://pasta.example"
 status: shipped
 cover: "ingredients.jpg"
 summary: "Rebuilt the order pipeline end-to-end; cut p99 latency from 3.2s to under a second."
 featured: true
-tags: [backend, distributed-systems]
+tags: [go, postgres, terraform, kafka, backend, distributed-systems]
 ---
 
 {{< results >}}

--- a/demo/content/projects/pasta-pipeline/index.md
+++ b/demo/content/projects/pasta-pipeline/index.md
@@ -4,7 +4,7 @@ date: 2025-03-12
 role: "Lead engineer"
 client: "Trattoria della Nonna"
 period: "2024 – 2025"
-stack: [go, postgres, terraform, kafka]
+stacks: [go, postgres, terraform, kafka]
 repo: "https://github.com/example/pasta-pipeline"
 live_url: "https://pasta.example"
 status: shipped

--- a/demo/content/projects/queue-garden.md
+++ b/demo/content/projects/queue-garden.md
@@ -1,0 +1,19 @@
+---
+title: "Queue Garden"
+date: 2026-01-15
+role: "Solo"
+period: "2026 –"
+tags: [rust, queues, visualization, developer-tools]
+repo: "https://github.com/example/queue-garden"
+status: wip
+summary: "An interactive queue simulator for testing retry policies and backpressure behavior."
+---
+
+Queue Garden is a work-in-progress tool for experimenting with retry,
+dead-letter, and backpressure settings without touching production
+queues.
+
+## Status
+
+The simulation core runs locally. The next step is a scenario editor
+that can save and replay traffic patterns.

--- a/demo/content/projects/rss-bridge.md
+++ b/demo/content/projects/rss-bridge.md
@@ -1,0 +1,18 @@
+---
+title: "RSS Bridge"
+date: 2021-04-19
+role: "Solo"
+period: "2020 – 2021"
+tags: [ruby, rss, automation]
+repo: "https://github.com/example/rss-bridge"
+status: closed
+summary: "A personal feed normalizer that cleaned noisy RSS sources before they reached a reader."
+---
+
+RSS Bridge was a personal automation project for normalizing feeds,
+deduplicating items, and smoothing over source-specific markup.
+
+## Why archived
+
+The reader workflow changed and the feed rules were too personal to
+justify maintaining as a public project.

--- a/demo/content/projects/theme-foundry.md
+++ b/demo/content/projects/theme-foundry.md
@@ -1,0 +1,18 @@
+---
+title: "Theme Foundry"
+date: 2024-12-03
+role: "Maintainer"
+period: "2024 –"
+tags: [hugo, css, design-systems]
+repo: "https://github.com/example/theme-foundry"
+status: wip
+summary: "A small Hugo theme lab for trying typography, color, and content layout experiments."
+---
+
+Theme Foundry collects small layout and typography experiments that may
+graduate into production themes.
+
+## Status
+
+The core fixtures are in place, but the palette and accessibility test
+matrix are still evolving.

--- a/demo/content/stacks/_index.md
+++ b/demo/content/stacks/_index.md
@@ -1,6 +1,0 @@
----
-title: "Stacks"
-description: "Technologies and tools used across project case studies."
----
-
-Each stack page links to the projects and writing that mention it.

--- a/demo/hugo.yaml
+++ b/demo/hugo.yaml
@@ -1,6 +1,11 @@
 title: "Er Demo"
 defaultContentLanguage: en
 
+taxonomies:
+  category: categories
+  tag: tags
+  stack: stacks
+
 languages:
   en:
     locale: en-US

--- a/demo/hugo.yaml
+++ b/demo/hugo.yaml
@@ -4,7 +4,6 @@ defaultContentLanguage: en
 taxonomies:
   category: categories
   tag: tags
-  stack: stacks
 
 languages:
   en:

--- a/docs/plans/003-readability-and-portfolio.org
+++ b/docs/plans/003-readability-and-portfolio.org
@@ -126,19 +126,17 @@ Smallest set that visibly raises the quality bar for prose.
 :END:
 
 - [X] ~archetypes/projects.md~ with structured frontmatter:
-  ~title~, ~date~, ~role~, ~client~, ~period~, ~stack: []~, ~repo~,
+  ~title~, ~date~, ~role~, ~client~, ~period~, ~tags: []~, ~repo~,
   ~live_url~, ~status~ (~shipped~ / ~wip~ / ~archived~), ~cover~,
   ~summary~, ~featured: false~.
-- [X] Register a ~stacks~ taxonomy in ~config/_default/hugo.yaml~ so
-  ~/stacks/rust/~ etc. work out of the box. (Default `category` and
-  `tag` taxonomies also declared explicitly so adding `stack` doesn't
-  silently drop them.)
+- [X] Use Hugo's default ~tags~ taxonomy for project technologies so
+  ~/tags/rust/~ etc. work out of the box without a custom taxonomy.
 - [X] Document the schema in ~README.md~ under a new "Projects" section.
 
 ** Track 2 layouts
 
 - [X] ~layouts/projects/single.html~ — case-study template:
-  hero/cover image, meta block (role, client, period, stack, status,
+  hero/cover image, meta block (role, client, period, tags, status,
   repo, live link), body. (Outcome strip + gallery land with the
   shortcode commit.)
 - [X] ~layouts/projects/list.html~ — grid of projects with cover thumbnail,
@@ -196,7 +194,8 @@ Suggested order. Each step is its own commit (or small series).
   (Leaning: follow system, persist override.)
 - Reading time: always on, or behind a site param? (Leaning: always on for
   posts, off for pages — gate by ~Section == "posts"~.)
-- Should ~stacks~ be a separate taxonomy or reuse ~tags~? (Leaning:
-  separate — tags describe topics, stacks describe technologies.)
+- Should ~stacks~ be a separate taxonomy or reuse ~tags~? Decided:
+  reuse ~tags~ so project technology links work without site-level
+  taxonomy configuration.
 - Copy-button on code blocks: inline JS in the partial, or a tiny
   ~static/js/~ file? (Leaning: tiny static file, loaded with ~defer~.)

--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -40,12 +40,18 @@ tableOfContents:
   other: Auf dieser Seite
 projects:
   other: Projekte
+post:
+  other: Beitrag
+project:
+  other: Projekt
 projectRole:
   other: Rolle
 projectClient:
   other: Kunde
 projectPeriod:
   other: Zeitraum
+projectTags:
+  other: Schlagworte
 projectStack:
   other: Stack
 projectStatus:

--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -60,9 +60,13 @@ projectLinks:
   other: Links
 projectStatus_shipped:
   other: Live
+projectStatus_active:
+  other: Aktiv
 projectStatus_wip:
   other: In Arbeit
 projectStatus_archived:
   other: Archiviert
+projectStatus_closed:
+  other: Geschlossen
 featuredProjects:
   other: Ausgewaehlte Arbeiten

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -40,12 +40,18 @@ tableOfContents:
   other: On this page
 projects:
   other: Projects
+post:
+  other: Post
+project:
+  other: Project
 projectRole:
   other: Role
 projectClient:
   other: Client
 projectPeriod:
   other: Period
+projectTags:
+  other: Tags
 projectStack:
   other: Stack
 projectStatus:

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -60,9 +60,13 @@ projectLinks:
   other: Links
 projectStatus_shipped:
   other: Shipped
+projectStatus_active:
+  other: Active
 projectStatus_wip:
   other: In progress
 projectStatus_archived:
   other: Archived
+projectStatus_closed:
+  other: Closed
 featuredProjects:
   other: Featured work

--- a/i18n/ja.yaml
+++ b/i18n/ja.yaml
@@ -40,12 +40,18 @@ tableOfContents:
   other: 目次
 projects:
   other: プロジェクト
+post:
+  other: 記事
+project:
+  other: プロジェクト
 projectRole:
   other: 役割
 projectClient:
   other: クライアント
 projectPeriod:
   other: 期間
+projectTags:
+  other: タグ
 projectStack:
   other: 使用技術
 projectStatus:

--- a/i18n/ja.yaml
+++ b/i18n/ja.yaml
@@ -60,9 +60,13 @@ projectLinks:
   other: リンク
 projectStatus_shipped:
   other: 公開済み
+projectStatus_active:
+  other: アクティブ
 projectStatus_wip:
   other: 開発中
 projectStatus_archived:
   other: アーカイブ済み
+projectStatus_closed:
+  other: 終了
 featuredProjects:
   other: 主なプロジェクト

--- a/layouts/_default/tag.html
+++ b/layouts/_default/tag.html
@@ -9,13 +9,15 @@
       <li class="leading-relaxed flex justify-between">
         <span>
           <a href="{{ .RelPermalink }}" class="no-underline text-base text-inherit hover:text-[var(--color-main-light)]">{{ .Title }}</a>
-          {{ if eq .Section "projects" }}
-          <span class="text-faint text-xs uppercase tracking-wide ml-2">{{ T "project" | default "Project" }}</span>
-          {{ else if eq .Section "posts" }}
-          <span class="text-faint text-xs uppercase tracking-wide ml-2">{{ T "post" | default "Post" }}</span>
-          {{ end }}
         </span>
-        <time>{{ .Date.Format "02 Jan 2006" }}</time>
+        <span>
+          {{ if eq .Section "projects" }}
+          <span class="text-faint text-xs uppercase tracking-wide mr-2">{{ T "project" | default "Project" }}</span>
+          {{ else if eq .Section "posts" }}
+          <span class="text-faint text-xs uppercase tracking-wide mr-2">{{ T "post" | default "Post" }}</span>
+          {{ end }}
+          <time>{{ .Date.Format "02 Jan 2006" }}</time>
+        </span>
       </li>
     {{ end }}
   </ul>

--- a/layouts/_default/tag.html
+++ b/layouts/_default/tag.html
@@ -7,7 +7,14 @@
   <ul class="list-none">
     {{ range .Data.Pages }}
       <li class="leading-relaxed flex justify-between">
-        <a href="{{ .RelPermalink }}" class="no-underline text-base text-inherit hover:text-[var(--color-main-light)]">{{ .Title }}</a>
+        <span>
+          <a href="{{ .RelPermalink }}" class="no-underline text-base text-inherit hover:text-[var(--color-main-light)]">{{ .Title }}</a>
+          {{ if eq .Section "projects" }}
+          <span class="text-faint text-xs uppercase tracking-wide ml-2">{{ T "project" | default "Project" }}</span>
+          {{ else if eq .Section "posts" }}
+          <span class="text-faint text-xs uppercase tracking-wide ml-2">{{ T "post" | default "Post" }}</span>
+          {{ end }}
+        </span>
         <time>{{ .Date.Format "02 Jan 2006" }}</time>
       </li>
     {{ end }}

--- a/layouts/_default/tag.html
+++ b/layouts/_default/tag.html
@@ -8,12 +8,12 @@
     {{ range .Data.Pages }}
       <li class="leading-relaxed flex justify-between">
         <span>
-          {{ if eq .Section "projects" }}
-          <span class="text-faint text-xs uppercase tracking-wide mr-2">{{ T "project" | default "Project" }}</span>
-          {{ else if eq .Section "posts" }}
-          <span class="text-faint text-xs uppercase tracking-wide mr-2">{{ T "post" | default "Post" }}</span>
-          {{ end }}
           <a href="{{ .RelPermalink }}" class="no-underline text-base text-inherit hover:text-[var(--color-main-light)]">{{ .Title }}</a>
+          {{ if eq .Section "projects" }}
+          <span class="text-faint text-xs uppercase tracking-wide ml-4">{{ T "project" | default "Project" }}</span>
+          {{ else if eq .Section "posts" }}
+          <span class="text-faint text-xs uppercase tracking-wide ml-4">{{ T "post" | default "Post" }}</span>
+          {{ end }}
         </span>
         <time>{{ .Date.Format "02 Jan 2006" }}</time>
       </li>

--- a/layouts/_default/tag.html
+++ b/layouts/_default/tag.html
@@ -8,16 +8,14 @@
     {{ range .Data.Pages }}
       <li class="leading-relaxed flex justify-between">
         <span>
+          {{ if eq .Section "projects" }}
+          <span class="text-faint text-xs uppercase tracking-wide mr-2">{{ T "project" | default "Project" }}</span>
+          {{ else if eq .Section "posts" }}
+          <span class="text-faint text-xs uppercase tracking-wide mr-2">{{ T "post" | default "Post" }}</span>
+          {{ end }}
           <a href="{{ .RelPermalink }}" class="no-underline text-base text-inherit hover:text-[var(--color-main-light)]">{{ .Title }}</a>
         </span>
-        <span>
-          {{ if eq .Section "projects" }}
-          <span class="text-faint text-xs uppercase tracking-wide mr-4">{{ T "project" | default "Project" }}</span>
-          {{ else if eq .Section "posts" }}
-          <span class="text-faint text-xs uppercase tracking-wide mr-4">{{ T "post" | default "Post" }}</span>
-          {{ end }}
-          <time>{{ .Date.Format "02 Jan 2006" }}</time>
-        </span>
+        <time>{{ .Date.Format "02 Jan 2006" }}</time>
       </li>
     {{ end }}
   </ul>

--- a/layouts/_default/tag.html
+++ b/layouts/_default/tag.html
@@ -12,9 +12,9 @@
         </span>
         <span>
           {{ if eq .Section "projects" }}
-          <span class="text-faint text-xs uppercase tracking-wide mr-2">{{ T "project" | default "Project" }}</span>
+          <span class="text-faint text-xs uppercase tracking-wide mr-4">{{ T "project" | default "Project" }}</span>
           {{ else if eq .Section "posts" }}
-          <span class="text-faint text-xs uppercase tracking-wide mr-2">{{ T "post" | default "Post" }}</span>
+          <span class="text-faint text-xs uppercase tracking-wide mr-4">{{ T "post" | default "Post" }}</span>
           {{ end }}
           <time>{{ .Date.Format "02 Jan 2006" }}</time>
         </span>

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -4,10 +4,10 @@
   <h1 class="text-2xl font-semibold font-sans">{{ .Title }}</h1>
   {{ partial "page-intro.html" . }}
   <ul class="list-none p-0">
-    {{ range $key, $value := .Data.Terms }}
+    {{ range .Data.Terms.Alphabetical }}
       <li class="leading-normal inline-block bg-[var(--color-background-alt)] px-1 m-1">
-        <a href="{{ $key | urlize }}" class="no-underline text-sm hover:border-[var(--color-body-text)] hover:text-[var(--color-body-text)]">
-          {{ $key }}&nbsp;({{ len $value }})
+        <a href="{{ .Page.RelPermalink }}" class="no-underline text-sm hover:border-[var(--color-body-text)] hover:text-[var(--color-body-text)]">
+          {{ .Page.LinkTitle }}&nbsp;({{ .Count }})
         </a>
       </li>
     {{ end }}

--- a/layouts/partials/featured-projects.html
+++ b/layouts/partials/featured-projects.html
@@ -17,7 +17,7 @@
       <a href="{{ .RelPermalink }}">
         <div class="featured-project-title-row">
           {{ if .Params.status }}
-          <span class="status-dot status-{{ .Params.status }}" title="{{ humanize .Params.status }}"></span>
+          {{ partial "project-status.html" (dict "status" .Params.status) }}
           {{ end }}
           <span class="featured-project-title">{{ .Title }}</span>
         </div>

--- a/layouts/partials/project-status.html
+++ b/layouts/partials/project-status.html
@@ -1,0 +1,11 @@
+{{- $status := .status -}}
+{{- if $status -}}
+{{- $class := $status -}}
+{{- if eq $status "active" -}}
+  {{- $class = "shipped" -}}
+{{- else if eq $status "closed" -}}
+  {{- $class = "archived" -}}
+{{- end -}}
+{{- $label := T (printf "projectStatus_%s" $status) | default (humanize $status) -}}
+<span class="status-dot status-{{ $class }}" title="{{ $label }}"></span>{{ if .label }}{{ $label }}{{ end }}
+{{- end -}}

--- a/layouts/projects/list.html
+++ b/layouts/projects/list.html
@@ -21,7 +21,7 @@
           {{ with $page.Params.summary }}
           <p class="project-card-summary">{{ . }}</p>
           {{ end }}
-          {{ with $page.Params.stack }}
+          {{ with (or $page.Params.stacks $page.Params.stack) }}
           <p class="project-card-stack">
             {{ range first 5 . }}<span class="stack-pill">{{ . }}</span>{{ end }}
           </p>

--- a/layouts/projects/list.html
+++ b/layouts/projects/list.html
@@ -11,7 +11,9 @@
     <li class="project-card">
       <a href="{{ $page.RelPermalink }}" class="project-card-link">
         {{ partial "project-cover.html" (dict "page" $page) }}
-        <div class="project-card-body">
+      </a>
+      <div class="project-card-body">
+        <a href="{{ $page.RelPermalink }}" class="project-card-link">
           <div class="project-card-title-row">
             {{ if $page.Params.status }}
             <span class="status-dot status-{{ $page.Params.status }}" title="{{ humanize $page.Params.status }}"></span>
@@ -21,13 +23,20 @@
           {{ with $page.Params.summary }}
           <p class="project-card-summary">{{ . }}</p>
           {{ end }}
-          {{ with $page.Params.tags }}
-          <p class="project-card-stack">
-            {{ range first 5 . }}<span class="stack-pill">{{ . }}</span>{{ end }}
-          </p>
+        </a>
+        {{ with $page.Params.tags }}
+        <p class="project-card-stack">
+          {{ range first 5 . }}
+          {{ $term := $.Site.GetPage (printf "/tags/%s" (. | urlize)) }}
+          {{ if $term }}
+          <a class="stack-pill" href="{{ $term.RelPermalink }}">{{ . }}</a>
+          {{ else }}
+          <span class="stack-pill">{{ . }}</span>
           {{ end }}
-        </div>
-      </a>
+          {{ end }}
+        </p>
+        {{ end }}
+      </div>
     </li>
     {{ end }}
   </ul>

--- a/layouts/projects/list.html
+++ b/layouts/projects/list.html
@@ -21,7 +21,7 @@
           {{ with $page.Params.summary }}
           <p class="project-card-summary">{{ . }}</p>
           {{ end }}
-          {{ with (or $page.Params.stacks $page.Params.stack) }}
+          {{ with $page.Params.tags }}
           <p class="project-card-stack">
             {{ range first 5 . }}<span class="stack-pill">{{ . }}</span>{{ end }}
           </p>

--- a/layouts/projects/list.html
+++ b/layouts/projects/list.html
@@ -6,7 +6,18 @@
   </header>
 
   <ul class="project-grid">
+    {{ $knownStatuses := slice "shipped" "active" "wip" "archived" "closed" }}
+    {{ $statusGroups := slice (slice "shipped" "active") (slice "wip") (slice "archived" "closed") }}
+    {{ $projects := slice }}
+    {{ range $statusGroups }}
+      {{ $projects = $projects | append (where $.Pages.ByDate.Reverse "Params.status" "in" .) }}
+    {{ end }}
     {{ range .Pages.ByDate.Reverse }}
+      {{ if not (in $knownStatuses .Params.status) }}
+        {{ $projects = $projects | append . }}
+      {{ end }}
+    {{ end }}
+    {{ range $projects }}
     {{ $page := . }}
     <li class="project-card">
       <a href="{{ $page.RelPermalink }}" class="project-card-link">
@@ -16,7 +27,7 @@
         <a href="{{ $page.RelPermalink }}" class="project-card-link">
           <div class="project-card-title-row">
             {{ if $page.Params.status }}
-            <span class="status-dot status-{{ $page.Params.status }}" title="{{ humanize $page.Params.status }}"></span>
+            {{ partial "project-status.html" (dict "status" $page.Params.status) }}
             {{ end }}
             <h2 class="project-card-title">{{ $page.Title }}</h2>
           </div>

--- a/layouts/projects/single.html
+++ b/layouts/projects/single.html
@@ -21,12 +21,12 @@
       {{ with .Params.period }}
       <div><dt>{{ T "projectPeriod" | default "Period" }}</dt><dd>{{ . }}</dd></div>
       {{ end }}
-      {{ with (or .Params.stacks .Params.stack) }}
+      {{ with .Params.tags }}
       <div>
-        <dt>{{ T "projectStack" | default "Stack" }}</dt>
+        <dt>{{ T "projectTags" | default "Tags" }}</dt>
         <dd>
           {{ range . }}
-          {{ $term := $.Site.GetPage (printf "/stacks/%s" (. | urlize)) }}
+          {{ $term := $.Site.GetPage (printf "/tags/%s" (. | urlize)) }}
           {{ if $term }}
           <a class="stack-pill" href="{{ $term.RelPermalink }}">{{ . }}</a>
           {{ else }}

--- a/layouts/projects/single.html
+++ b/layouts/projects/single.html
@@ -39,7 +39,7 @@
       {{ if .Params.status }}
       <div>
         <dt>{{ T "projectStatus" | default "Status" }}</dt>
-        <dd><span class="status-dot status-{{ .Params.status }}"></span>{{ T (printf "projectStatus_%s" .Params.status) | default (humanize .Params.status) }}</dd>
+        <dd>{{ partial "project-status.html" (dict "status" .Params.status "label" true) }}</dd>
       </div>
       {{ end }}
       {{ if or .Params.repo .Params.live_url }}

--- a/layouts/projects/single.html
+++ b/layouts/projects/single.html
@@ -21,12 +21,17 @@
       {{ with .Params.period }}
       <div><dt>{{ T "projectPeriod" | default "Period" }}</dt><dd>{{ . }}</dd></div>
       {{ end }}
-      {{ with .Params.stack }}
+      {{ with (or .Params.stacks .Params.stack) }}
       <div>
         <dt>{{ T "projectStack" | default "Stack" }}</dt>
         <dd>
           {{ range . }}
-          <a class="stack-pill" href='{{ "/stacks/" | relLangURL }}{{ . | urlize }}'>{{ . }}</a>
+          {{ $term := $.Site.GetPage (printf "/stacks/%s" (. | urlize)) }}
+          {{ if $term }}
+          <a class="stack-pill" href="{{ $term.RelPermalink }}">{{ . }}</a>
+          {{ else }}
+          <span class="stack-pill">{{ . }}</span>
+          {{ end }}
           {{ end }}
         </dd>
       </div>


### PR DESCRIPTION
## Summary

- use Hugo tags for project technology pills instead of a custom stacks taxonomy
- make project tag pills link to `/tags/<term>/` from both project cards and project pages
- label mixed tag result pages as Post or Project
- sort projects by status priority: shipped/active, then wip, then archived/closed, with newest first in each group
- map `active` to the shipped status style and `closed` to the archived status style
- expand demo project content to showcase tag links and status ordering

## Verification

- `hugo --source demo --cleanDestinationDir --destination /private/tmp/er-demo-project-status-sort-test`
- `hugo --source demo -b http://example.test --cleanDestinationDir --destination /private/tmp/er-demo-project-status-sort-example-test`
- `hugo --minify --destination /private/tmp/er-root-project-status-sort-test`
- `git diff --check`