### PR TITLE
fix(orb): prepare Nix and Tailscale lifecycle

### DIFF
--- a/.agents/resume
+++ b/.agents/resume
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+nix_daemon_profile="/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh"
+
+if [ -f "$nix_daemon_profile" ]; then
+  unset __ETC_PROFILE_NIX_SOURCED
+  # shellcheck disable=SC1091
+  source "$nix_daemon_profile"
+fi
+
+if ! command -v nix >/dev/null 2>&1; then
+  echo "Nix is unavailable; run .agents/setup to repair this orb."
+  exit 1
+fi
+
+if ! nix flake metadata "$repo_root" --no-write-lock-file >/dev/null; then
+  echo "The Nix development shell could not be evaluated; run .agents/setup to repair this orb."
+  exit 1
+fi
+
+echo "Nix development shell is ready."

--- a/.agents/resume
+++ b/.agents/resume
@@ -21,8 +21,13 @@ if ! nix flake metadata "$repo_root" --no-write-lock-file >/dev/null; then
 fi
 
 if command -v tailscale >/dev/null 2>&1; then
-  if ! timeout 3s sudo systemctl restart tailscaled || \
-    ! timeout 3s sudo tailscale status --json | grep -q '"BackendState": "Running"'; then
+  if ! timeout 3s sudo systemctl restart tailscaled; then
+    echo "Tailscale did not reconnect during resume; run .agents/setup after verifying the tailnet trust policy." >&2
+    exit 1
+  fi
+
+  if ! tailscale_status="$(timeout 3s sudo tailscale status --json)" || \
+    ! grep -q '"BackendState": "Running"' <<<"$tailscale_status"; then
     echo "Tailscale did not reconnect during resume; run .agents/setup after verifying the tailnet trust policy." >&2
     exit 1
   fi

--- a/.agents/resume
+++ b/.agents/resume
@@ -1,42 +1,23 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 nix_daemon_profile="/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh"
-# shellcheck disable=SC1091
-source "$(dirname "${BASH_SOURCE[0]}")/tailscale.sh"
 
-if [ -f "$nix_daemon_profile" ]; then
-  unset __ETC_PROFILE_NIX_SOURCED
-  # shellcheck disable=SC1091
-  source "$nix_daemon_profile"
-fi
-
-if ! command -v nix >/dev/null 2>&1; then
-  echo "Nix is unavailable; run .agents/setup to repair this orb."
-  exit 1
-fi
-
-if ! nix flake metadata "$repo_root" --no-write-lock-file >/dev/null; then
-  echo "The Nix development shell could not be evaluated; run .agents/setup to repair this orb."
-  exit 1
-fi
-
-if ! command -v tailscale >/dev/null 2>&1; then
-  echo "Tailscale is unavailable; run .agents/setup to repair this orb." >&2
-  exit 1
-fi
-
-if ! timeout 2s sudo systemctl restart tailscaled; then
-  echo "Tailscale did not restart during resume; run .agents/setup to repair this orb." >&2
-  exit 1
-fi
-
-if ! tailscale_wait 2s; then
-  if ! tailscale_require_configuration || ! tailscale_enroll 3s || ! tailscale_wait 2s; then
-    echo "Tailscale did not reconnect during resume; run .agents/setup after verifying the tailnet trust policy." >&2
-    exit 1
+if ! timeout --kill-after=0.5s 8s bash -c '
+  set -euo pipefail
+  source "$1"
+  if [ -f "$2" ]; then
+    unset __ETC_PROFILE_NIX_SOURCED
+    source "$2"
   fi
+  command -v nix >/dev/null 2>&1
+  command -v tailscale >/dev/null 2>&1
+  timeout 2s sudo systemctl restart tailscaled
+  tailscale_require_configuration
+  tailscale_login_and_wait 5s 3s 2s
+' bash "$(dirname "${BASH_SOURCE[0]}")/tailscale.sh" "$nix_daemon_profile"; then
+  echo "Tailscale did not reconnect during resume; run .agents/setup after verifying the tailnet trust policy." >&2
+  exit 1
 fi
 
 echo "Nix development shell is ready."

--- a/.agents/resume
+++ b/.agents/resume
@@ -20,4 +20,12 @@ if ! nix flake metadata "$repo_root" --no-write-lock-file >/dev/null; then
   exit 1
 fi
 
+if command -v tailscale >/dev/null 2>&1; then
+  if ! timeout 3s sudo systemctl restart tailscaled || \
+    ! timeout 3s sudo tailscale status --json | grep -q '"BackendState": "Running"'; then
+    echo "Tailscale did not reconnect during resume; run .agents/setup after verifying the tailnet trust policy." >&2
+    exit 1
+  fi
+fi
+
 echo "Nix development shell is ready."

--- a/.agents/resume
+++ b/.agents/resume
@@ -3,6 +3,8 @@ set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 nix_daemon_profile="/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh"
+# shellcheck disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/tailscale.sh"
 
 if [ -f "$nix_daemon_profile" ]; then
   unset __ETC_PROFILE_NIX_SOURCED
@@ -20,14 +22,18 @@ if ! nix flake metadata "$repo_root" --no-write-lock-file >/dev/null; then
   exit 1
 fi
 
-if command -v tailscale >/dev/null 2>&1; then
-  if ! timeout 3s sudo systemctl restart tailscaled; then
-    echo "Tailscale did not reconnect during resume; run .agents/setup after verifying the tailnet trust policy." >&2
-    exit 1
-  fi
+if ! command -v tailscale >/dev/null 2>&1; then
+  echo "Tailscale is unavailable; run .agents/setup to repair this orb." >&2
+  exit 1
+fi
 
-  if ! tailscale_status="$(timeout 3s sudo tailscale status --json)" || \
-    ! grep -q '"BackendState": "Running"' <<<"$tailscale_status"; then
+if ! timeout 2s sudo systemctl restart tailscaled; then
+  echo "Tailscale did not restart during resume; run .agents/setup to repair this orb." >&2
+  exit 1
+fi
+
+if ! tailscale_wait 2s; then
+  if ! tailscale_require_configuration || ! tailscale_enroll 3s || ! tailscale_wait 2s; then
     echo "Tailscale did not reconnect during resume; run .agents/setup after verifying the tailnet trust policy." >&2
     exit 1
   fi

--- a/.agents/setup
+++ b/.agents/setup
@@ -67,7 +67,7 @@ sudo systemctl daemon-reload
 sudo systemctl enable tailscaled
 sudo systemctl restart tailscaled
 
-if ! tailscale_enroll 60s; then
+if ! tailscale_enroll_and_wait 60s 55s 5s; then
   exit 1
 fi
 

--- a/.agents/setup
+++ b/.agents/setup
@@ -6,10 +6,16 @@ nix_profile="$HOME/.nix-profile"
 nix_binary="/nix/var/nix/profiles/default/bin/nix"
 nix_daemon_profile="/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh"
 profile_marker="# er Hugo theme Nix development shell"
+tailscale_tag="tag:amp-demo"
 
 log_step() {
   printf '\n==> %s\n' "$1"
 }
+
+if [ -z "${TAILSCALE_CLIENT_ID:-}" ] || [ -z "${TAILSCALE_TRUST_AUDIENCE:-}" ]; then
+  echo "TAILSCALE_CLIENT_ID and TAILSCALE_TRUST_AUDIENCE must be configured for remote orbs." >&2
+  exit 1
+fi
 
 log_step "Installing Nix when needed"
 if [ ! -x "$nix_binary" ]; then
@@ -39,6 +45,44 @@ nix develop "$repo_root" --command bash -c '
   command -v tailwindcss
   command -v go
 '
+
+if ! command -v tailscale >/dev/null 2>&1; then
+  log_step "Installing Tailscale"
+  curl -fsSL https://pkgs.tailscale.com/stable/debian/bookworm.noarmor.gpg |
+    sudo tee /usr/share/keyrings/tailscale-archive-keyring.gpg >/dev/null
+  curl -fsSL https://pkgs.tailscale.com/stable/debian/bookworm.tailscale-keyring.list |
+    sudo tee /etc/apt/sources.list.d/tailscale.list >/dev/null
+  sudo apt-get update
+  sudo apt-get install -y tailscale
+fi
+
+log_step "Configuring Tailscale for the orb network"
+sudo install -d /etc/systemd/system/tailscaled.service.d
+sudo tee /etc/systemd/system/tailscaled.service.d/amp-orb.conf >/dev/null <<'EOF'
+[Service]
+Environment=TS_ASSUME_NETWORK_UP_FOR_TEST=true
+EOF
+sudo systemctl daemon-reload
+sudo systemctl enable tailscaled
+sudo systemctl restart tailscaled
+
+if ! tailscale_identity_token="$(
+  amp orb id-token --audience "$TAILSCALE_TRUST_AUDIENCE" --ttl-seconds 600
+)"; then
+  echo "Amp workload identity is unavailable; rerun setup from an Amp-managed orb." >&2
+  exit 1
+fi
+
+if ! sudo tailscale up \
+  --client-id="${TAILSCALE_CLIENT_ID}?ephemeral=true&preauthorized=true" \
+  --id-token="$tailscale_identity_token" \
+  --advertise-tags="$tailscale_tag" \
+  --hostname="amp-er-${HOSTNAME##*-}"; then
+  unset tailscale_identity_token
+  echo "Tailscale enrollment failed. Configure the Amp OIDC trust credential and $tailscale_tag policy before rerunning setup." >&2
+  exit 1
+fi
+unset tailscale_identity_token
 
 log_step "Configuring the login-shell development environment"
 touch "$HOME/.bash_profile"

--- a/.agents/setup
+++ b/.agents/setup
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+nix_profile="$HOME/.nix-profile"
+nix_binary="/nix/var/nix/profiles/default/bin/nix"
+nix_daemon_profile="/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh"
+profile_marker="# er Hugo theme Nix development shell"
+
+log_step() {
+  printf '\n==> %s\n' "$1"
+}
+
+log_step "Installing Nix when needed"
+if [ ! -x "$nix_binary" ]; then
+  sudo apt-get update
+  sudo apt-get install -y --no-install-recommends ca-certificates curl xz-utils
+  sh <(curl -fsSL https://nixos.org/nix/install) --daemon --yes
+fi
+
+if ! sudo grep -Eq '^experimental-features[[:space:]]*=' /etc/nix/nix.conf; then
+  printf '%s\n' 'experimental-features = nix-command flakes' | sudo tee -a /etc/nix/nix.conf >/dev/null
+fi
+
+# The installer cannot update this script's environment.
+if [ -f "$nix_daemon_profile" ]; then
+  unset __ETC_PROFILE_NIX_SOURCED
+  # shellcheck disable=SC1091
+  source "$nix_daemon_profile"
+else
+  # shellcheck disable=SC1091
+  source "$nix_profile/etc/profile.d/nix.sh"
+fi
+
+log_step "Warming the pinned Nix development shell"
+nix develop "$repo_root" --command bash -c '
+  command -v hugo
+  command -v pagefind
+  command -v tailwindcss
+  command -v go
+'
+
+log_step "Configuring the login-shell development environment"
+touch "$HOME/.bash_profile"
+if ! grep -Fqx "$profile_marker" "$HOME/.bash_profile"; then
+  {
+    printf '\n%s\n' "$profile_marker"
+    printf '%s\n' 'if [[ -z "${IN_NIX_SHELL:-}" && -z "${AMP_ER_NIX_ENV_LOADED:-}" && ( "${PWD}" == '"$repo_root"' || "${PWD}" == '"$repo_root"'/* ) ]]; then'
+    printf '%s\n' '  if ! command -v nix >/dev/null 2>&1 && [ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then'
+    printf '%s\n' '    unset __ETC_PROFILE_NIX_SOURCED'
+    printf '%s\n' '    source /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'
+    printf '%s\n' '  fi'
+    printf '%s\n' '  export AMP_ER_NIX_ENV_LOADED=1'
+    printf '%s\n' '  eval "$(nix print-dev-env '"$repo_root"')"'
+    printf '%s\n' 'fi'
+  } >> "$HOME/.bash_profile"
+fi
+
+log_step "Setup complete"

--- a/.agents/setup
+++ b/.agents/setup
@@ -5,15 +5,16 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 nix_profile="$HOME/.nix-profile"
 nix_binary="/nix/var/nix/profiles/default/bin/nix"
 nix_daemon_profile="/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh"
-profile_marker="# er Hugo theme Nix development shell"
-tailscale_tag="tag:amp-demo"
+profile_start_marker="# >>> er Hugo theme Nix development shell >>>"
+profile_end_marker="# <<< er Hugo theme Nix development shell <<<"
+# shellcheck disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/tailscale.sh"
 
 log_step() {
   printf '\n==> %s\n' "$1"
 }
 
-if [ -z "${TAILSCALE_CLIENT_ID:-}" ] || [ -z "${TAILSCALE_TRUST_AUDIENCE:-}" ]; then
-  echo "TAILSCALE_CLIENT_ID and TAILSCALE_TRUST_AUDIENCE must be configured for remote orbs." >&2
+if ! tailscale_require_configuration; then
   exit 1
 fi
 
@@ -66,38 +67,34 @@ sudo systemctl daemon-reload
 sudo systemctl enable tailscaled
 sudo systemctl restart tailscaled
 
-if ! tailscale_identity_token="$(
-  amp orb id-token --audience "$TAILSCALE_TRUST_AUDIENCE" --ttl-seconds 600
-)"; then
-  echo "Amp workload identity is unavailable; rerun setup from an Amp-managed orb." >&2
+if ! tailscale_enroll 60s; then
   exit 1
 fi
-
-if ! sudo tailscale up \
-  --client-id="${TAILSCALE_CLIENT_ID}?ephemeral=true&preauthorized=true" \
-  --id-token="$tailscale_identity_token" \
-  --advertise-tags="$tailscale_tag" \
-  --hostname="amp-er-${HOSTNAME##*-}"; then
-  unset tailscale_identity_token
-  echo "Tailscale enrollment failed. Configure the Amp OIDC trust credential and $tailscale_tag policy before rerunning setup." >&2
-  exit 1
-fi
-unset tailscale_identity_token
 
 log_step "Configuring the login-shell development environment"
 touch "$HOME/.bash_profile"
-if ! grep -Fqx "$profile_marker" "$HOME/.bash_profile"; then
-  {
-    printf '\n%s\n' "$profile_marker"
-    printf '%s\n' 'if [[ -z "${IN_NIX_SHELL:-}" && -z "${AMP_ER_NIX_ENV_LOADED:-}" && ( "${PWD}" == '"$repo_root"' || "${PWD}" == '"$repo_root"'/* ) ]]; then'
-    printf '%s\n' '  if ! command -v nix >/dev/null 2>&1 && [ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then'
-    printf '%s\n' '    unset __ETC_PROFILE_NIX_SOURCED'
-    printf '%s\n' '    source /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'
-    printf '%s\n' '  fi'
-    printf '%s\n' '  export AMP_ER_NIX_ENV_LOADED=1'
-    printf '%s\n' '  eval "$(nix print-dev-env '"$repo_root"')"'
-    printf '%s\n' 'fi'
-  } >> "$HOME/.bash_profile"
+if grep -Fqx '# er Hugo theme Nix development shell' "$HOME/.bash_profile"; then
+  sed -i '/^# er Hugo theme Nix development shell$/,$d' "$HOME/.bash_profile"
 fi
+awk -v start="$profile_start_marker" -v end="$profile_end_marker" '
+  $0 == start { skip = 1; next }
+  $0 == end { skip = 0; next }
+  !skip { print }
+' "$HOME/.bash_profile" > "$HOME/.bash_profile.amp-tmp"
+{
+  printf '\n%s\n' "$profile_start_marker"
+  printf '%s\n' 'if [[ -z "${IN_NIX_SHELL:-}" && -z "${AMP_ER_NIX_ENV_LOADED:-}" && ( "${PWD}" == '"$repo_root"' || "${PWD}" == '"$repo_root"'/* ) ]]; then'
+  printf '%s\n' '  if ! command -v nix >/dev/null 2>&1 && [ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then'
+  printf '%s\n' '    unset __ETC_PROFILE_NIX_SOURCED'
+  printf '%s\n' '    source /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'
+  printf '%s\n' '  fi'
+  printf '%s\n' '  if nix_dev_env="$(nix print-dev-env '"$repo_root"')"; then'
+  printf '%s\n' '    eval "$nix_dev_env"'
+  printf '%s\n' '    export AMP_ER_NIX_ENV_LOADED=1'
+  printf '%s\n' '  fi'
+  printf '%s\n' 'fi'
+  printf '%s\n' "$profile_end_marker"
+} >> "$HOME/.bash_profile.amp-tmp"
+mv "$HOME/.bash_profile.amp-tmp" "$HOME/.bash_profile"
 
 log_step "Setup complete"

--- a/.agents/tailscale.sh
+++ b/.agents/tailscale.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+tailscale_tag="tag:amp-demo"
+tailscale_hostname="amp-er-${HOSTNAME##*-}"
+
+tailscale_require_configuration() {
+  if [ -z "${TAILSCALE_CLIENT_ID:-}" ] || [ -z "${TAILSCALE_TRUST_AUDIENCE:-}" ]; then
+    echo "TAILSCALE_CLIENT_ID and TAILSCALE_TRUST_AUDIENCE must be configured for remote orbs." >&2
+    return 1
+  fi
+}
+
+tailscale_enroll() {
+  local timeout="$1"
+  local identity_token
+
+  if ! identity_token="$(
+    amp orb id-token --audience "$TAILSCALE_TRUST_AUDIENCE" --ttl-seconds 600
+  )"; then
+    echo "Amp workload identity is unavailable; rerun setup from an Amp-managed orb." >&2
+    return 1
+  fi
+
+  if ! sudo tailscale up \
+    --timeout="$timeout" \
+    --client-id="${TAILSCALE_CLIENT_ID}?ephemeral=true&preauthorized=true" \
+    --id-token="$identity_token" \
+    --advertise-tags="$tailscale_tag" \
+    --hostname="$tailscale_hostname"; then
+    unset identity_token
+    echo "Tailscale enrollment failed. Configure the Amp OIDC trust credential and $tailscale_tag policy before rerunning setup." >&2
+    return 1
+  fi
+
+  unset identity_token
+}
+
+tailscale_wait() {
+  timeout "$1" sudo tailscale wait --timeout="$1"
+}

--- a/.agents/tailscale.sh
+++ b/.agents/tailscale.sh
@@ -10,21 +10,22 @@ tailscale_require_configuration() {
   fi
 }
 
-tailscale_enroll() {
-  local timeout="$1"
+tailscale_authenticate() {
+  local command="$1"
+  local timeout="$2"
   local identity_token
 
   if ! identity_token="$(
-    amp orb id-token --audience "$TAILSCALE_TRUST_AUDIENCE" --ttl-seconds 600
+    timeout "$timeout" amp orb id-token --audience "$TAILSCALE_TRUST_AUDIENCE" --ttl-seconds 600
   )"; then
     echo "Amp workload identity is unavailable; rerun setup from an Amp-managed orb." >&2
     return 1
   fi
 
-  if ! sudo tailscale up \
+  if ! printf '%s' "$identity_token" | timeout "$timeout" sudo tailscale "$command" \
     --timeout="$timeout" \
     --client-id="${TAILSCALE_CLIENT_ID}?ephemeral=true&preauthorized=true" \
-    --id-token="$identity_token" \
+    --id-token=file:/dev/stdin \
     --advertise-tags="$tailscale_tag" \
     --hostname="$tailscale_hostname"; then
     unset identity_token
@@ -35,6 +36,40 @@ tailscale_enroll() {
   unset identity_token
 }
 
+tailscale_enroll() {
+  tailscale_authenticate up "$1"
+}
+
+tailscale_login() {
+  tailscale_authenticate login "$1"
+}
+
 tailscale_wait() {
   timeout "$1" sudo tailscale wait --timeout="$1"
+}
+
+tailscale_enroll_and_wait() {
+  local deadline="$1"
+  local enrollment_timeout="$2"
+  local readiness_timeout="$3"
+
+  timeout "$deadline" bash -c '
+    set -euo pipefail
+    source "$1"
+    tailscale_enroll "$2"
+    tailscale_wait "$3"
+  ' bash "${BASH_SOURCE[0]}" "$enrollment_timeout" "$readiness_timeout"
+}
+
+tailscale_login_and_wait() {
+  local deadline="$1"
+  local enrollment_timeout="$2"
+  local readiness_timeout="$3"
+
+  timeout "$deadline" bash -c '
+    set -euo pipefail
+    source "$1"
+    tailscale_login "$2"
+    tailscale_wait "$3"
+  ' bash "${BASH_SOURCE[0]}" "$enrollment_timeout" "$readiness_timeout"
 }


### PR DESCRIPTION
## Summary
- add executable Amp orb setup and resume lifecycle scripts using the pinned Nix development shell
- enroll fresh and resumed ephemeral orb nodes with short-lived Amp OIDC credentials for Tailscale
- bound resume recovery and make the persisted Nix profile activation replaceable and retryable

## Verification
- `bash -n .agents/setup .agents/resume .agents/tailscale.sh`
- `.agents/setup` twice (warm runs completed successfully)
- `.agents/resume` with fresh Tailscale OIDC login recovery (completed in ~4 seconds)
- clean non-interactive login-shell tool checks
- `make build` through the Nix environment
- Oracle review of all changes since `78a2f0b50e7bddcfda45fea5bfe6263501ed2fee`