### PR TITLE
fix(theme): improve accessibility and build reliability

### DIFF
--- a/.agents/setup
+++ b/.agents/setup
@@ -44,7 +44,10 @@ nix develop "$repo_root" --command bash -c '
   command -v hugo
   command -v pagefind
   command -v tailwindcss
+  command -v watchman
   command -v go
+  command -v jj
+  command -v ruby
 '
 
 if ! command -v tailscale >/dev/null 2>&1; then

--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -1,4 +1,4 @@
-name: PR Conventional Commit Validation
+name: Pull Request Checks
 
 on:
   pull_request:
@@ -9,7 +9,32 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: PR Conventional Commit Validation
-        uses: ytanikin/pr-conventional-commits@1.5.2
+        uses: ytanikin/pr-conventional-commits@639145d78959c53c43112365837e3abd21ed67c1 # 1.5.2
         with:
           # This list should match cliff.toml.
           task_types: '["feat","fix","doc","docs","test","ci","refactor","perf","chore","revert","style","security"]'
+
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@786fff0690178f1234e4e1fe9b536e94f5433196 # v20
+
+      - name: Build theme and Pagefind index
+        run: nix develop -c make build
+
+      - name: Check generated CSS
+        run: git diff --exit-code -- assets/css/main.css
+
+      - name: Build multilingual demo and Pagefind index
+        working-directory: demo
+        run: nix develop .. -c sh -c 'hugo -b http://example.test && pagefind --site public'
+
+      - name: Validate plan status
+        run: scripts/check-plan-status.sh
+
+      - name: Validate workflow YAML
+        run: nix develop -c ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |f| YAML.load_file(f) }'

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -52,13 +52,13 @@ jobs:
     steps:
       - name: Create release app token
         id: release-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
           token: ${{ steps.release-token.outputs.token }}
@@ -106,7 +106,7 @@ jobs:
       - name: Compute next version
         if: steps.skip.outputs.skip == 'false' && steps.changes.outputs.ahead != '0'
         id: next-version
-        uses: orhun/git-cliff-action@v4
+        uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4
         with:
           config: cliff.toml
           args: --bumped-version
@@ -144,7 +144,7 @@ jobs:
 
       - name: Generate changelog
         if: steps.skip.outputs.skip == 'false' && steps.changes.outputs.ahead != '0' && steps.version-check.outputs.skip == 'false'
-        uses: orhun/git-cliff-action@v4
+        uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4
         with:
           config: cliff.toml
           args: --tag ${{ steps.normalized-version.outputs.tag }}
@@ -154,7 +154,7 @@ jobs:
 
       - name: Generate release notes preview
         if: steps.skip.outputs.skip == 'false' && steps.changes.outputs.ahead != '0' && steps.version-check.outputs.skip == 'false'
-        uses: orhun/git-cliff-action@v4
+        uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4
         with:
           config: cliff.toml
           args: --unreleased --tag ${{ steps.normalized-version.outputs.tag }} --strip header

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -19,13 +19,13 @@ jobs:
     steps:
       - name: Create release app token
         id: release-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.merge_commit_sha }}
@@ -33,9 +33,11 @@ jobs:
 
       - name: Determine release tag
         id: release
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           git fetch --tags origin
-          pr_title='${{ github.event.pull_request.title }}'
+          pr_title="${PR_TITLE}"
 
           if ! printf '%s\n' "${pr_title}" | grep -Eq '^chore\(release\): v[0-9]+\.[0-9]+\.[0-9]+$'; then
             echo "Release PR title is not a valid release title: ${pr_title}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,13 +18,48 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout tagged commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
           ref: ${{ github.ref }}
 
+      - name: Validate release tag
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          if ! printf '%s\n' "${TAG_NAME}" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "Invalid release tag: ${TAG_NAME}"
+            exit 1
+          fi
+
+          if ! grep -Eq "^## ${TAG_NAME} - " CHANGELOG.md; then
+            echo "Tagged commit does not contain a changelog entry for ${TAG_NAME}"
+            exit 1
+          fi
+
+          latest_tag="$(sed -nE 's/^## (v[0-9]+\.[0-9]+\.[0-9]+) - .*/\1/p' CHANGELOG.md | head -n 1)"
+          if [ "${TAG_NAME}" != "${latest_tag}" ]; then
+            echo "Release tag ${TAG_NAME} does not match latest changelog entry ${latest_tag}"
+            exit 1
+          fi
+
+          git fetch origin main
+          if ! git merge-base --is-ancestor "${GITHUB_SHA}" origin/main; then
+            echo "Tagged commit is not on main"
+            exit 1
+          fi
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@786fff0690178f1234e4e1fe9b536e94f5433196 # v20
+
+      - name: Verify tagged build
+        run: nix develop -c make build
+
+      - name: Check generated CSS
+        run: git diff --exit-code -- assets/css/main.css
+
       - name: Generate release notes
-        uses: orhun/git-cliff-action@v4
+        uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4
         with:
           config: cliff.toml
           args: --latest --strip header

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,33 @@
+SHELL := /bin/bash
+
 .PHONY: dev
-dev:
+dev: css
 	hugo --source demo --destination public --cleanDestinationDir -b http://127.0.0.1:1414/
 	pagefind --site demo/public --silent
-	@trap 'kill $$hugo_pid $$pagefind_pid 2>/dev/null' INT TERM EXIT; \
+	@set -u; \
+	cleanup() { \
+		trap - EXIT INT TERM; \
+		kill $$hugo_pid $$pagefind_pid $$css_pid 2>/dev/null || true; \
+		wait $$hugo_pid $$pagefind_pid $$css_pid 2>/dev/null || true; \
+	}; \
+	trap cleanup EXIT; \
+	trap 'exit 130' INT; \
+	trap 'exit 143' TERM; \
 	hugo server --source demo --destination public --disableFastRender -b http://127.0.0.1:1414/ --port 1414 & \
 	hugo_pid=$$!; \
-	watchexec --postpone --watch demo/content --watch demo/hugo.yaml --watch layouts --watch assets --watch static --watch config --debounce 1sec --delay-run 500ms -- pagefind --site demo/public --silent & \
+	watchexec --postpone --watch demo/public --ignore 'demo/public/pagefind/**' --debounce 1sec -- pagefind --site demo/public --silent & \
 	pagefind_pid=$$!; \
-	wait $$hugo_pid
+	tailwindcss -i ./assets/css/app.css -o ./assets/css/main.css --watch=always & \
+	css_pid=$$!; \
+	set +e; \
+	wait -n $$hugo_pid $$pagefind_pid $$css_pid; \
+	status=$$?; \
+	set -e; \
+	if [ $$status -eq 0 ]; then \
+		echo "A development watcher exited unexpectedly" >&2; \
+		exit 1; \
+	fi; \
+	exit $$status
 
 .PHONY: css
 css:

--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ Helpful shortcodes inside a project page:
 - `{{< gallery >}}` — responsive image grid with lightbox.
 - `{{< results >}} ... {{< /results >}}` — metric strip at the top of
   a case study.
+- `{{< figure src="cover.jpg" alt="Description" caption="Caption" >}}` —
+  image with an optional caption. Its optional `class` argument accepts CSS
+  classes already supplied by the theme or your site's custom stylesheet;
+  downstream Tailwind utility names are not compiled into the theme asset.
 
 Project stack pills use Hugo's default `tags` taxonomy, so terms like
 `go` and `postgres` link to `/tags/go/` and `/tags/postgres/`.
@@ -297,16 +301,14 @@ To run the demo site from the repository root:
 make dev
 ```
 
-This builds the demo into `demo/public/`, rebuilds its Pagefind index, and then
-starts Hugo's live-reload server at `http://127.0.0.1:1414/`. While the server
-runs, a file watcher refreshes `demo/public/pagefind/` after content, template,
-asset, or config changes.
+This regenerates the theme CSS, builds the demo into `demo/public/`, rebuilds
+its Pagefind index, and then starts Hugo's live-reload server at
+`http://127.0.0.1:1414/`. While the server runs, file watchers refresh both the
+generated CSS and `demo/public/pagefind/` after relevant changes. Running
+`make dev` from `demo/` delegates to the same workflow.
 
-To modify the theme styles:
-
-1. Run `make dev` from the repo root
-2. Run `make css-watch` from the repo root to rebuild CSS live as the demo
-   templates change
+Use `make css-watch` only when you want to rebuild theme styles without running
+the demo server.
 
 At the theme root, `make build` runs `pagefind --site public` after Hugo and
 writes `public/pagefind/` for the root fixture.

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -6,7 +6,6 @@
     --font-sans: "Source Sans Pro", sans-serif;
     --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
     monospace;
-    --color-gray-300: oklch(87.2% 0.01 258.338);
     --color-black: #000;
     --color-white: #fff;
     --spacing: 0.25rem;
@@ -207,6 +206,17 @@
 @layer utilities {
   .visible {
     visibility: visible;
+  }
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border-width: 0;
   }
   .absolute {
     position: absolute;
@@ -1521,13 +1531,6 @@
     &:hover {
       @media (hover: hover) {
         color: var(--color-main-light);
-      }
-    }
-  }
-  .hover\:text-gray-300 {
-    &:hover {
-      @media (hover: hover) {
-        color: var(--color-gray-300);
       }
     }
   }

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -1,3 +1,3 @@
 .PHONY: dev
 dev:
-	hugo serve
+	$(MAKE) -C .. dev

--- a/flake.nix
+++ b/flake.nix
@@ -77,10 +77,13 @@
             pagefind
             tailwindcssV4
             watchexec
+            watchman
             go # Added Go for Hugo modules
+            jujutsu
 
             # Tools
             git-cliff
+            ruby
             yaml-language-server
             vscode-json-languageserver
             tailwindcss-language-server

--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -6,6 +6,12 @@ languageSwitcher:
   other: Sprachen
 menu:
   other: Menue
+backToTop:
+  other: Nach oben
+imagePreview:
+  other: Bildvorschau
+closeImagePreview:
+  other: Bildvorschau schliessen
 tags:
   other: Schlagworte
 categories:

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -6,6 +6,12 @@ languageSwitcher:
   other: Languages
 menu:
   other: Menu
+backToTop:
+  other: Back to top
+imagePreview:
+  other: Image preview
+closeImagePreview:
+  other: Close image preview
 tags:
   other: tags
 categories:

--- a/i18n/ja.yaml
+++ b/i18n/ja.yaml
@@ -6,6 +6,12 @@ languageSwitcher:
   other: 言語
 menu:
   other: メニュー
+backToTop:
+  other: ページ上部へ
+imagePreview:
+  other: 画像プレビュー
+closeImagePreview:
+  other: 画像プレビューを閉じる
 tags:
   other: タグ
 categories:

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
 <main class="content-shell my-8 px-3">
-  <div class="text-4xl font-semibold text-[var(--color-heading-text)] font-sans">404</div>
+  <h1 class="text-4xl font-semibold text-[var(--color-heading-text)] font-sans">404</h1>
   <p class="leading-normal prose text-xl">
     {{ T "notFound" }} <br>
     {{ T "findSomething" }} <a href='{{ "" | relLangURL }}'>{{ T "interestingToRead" }}</a>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -3,9 +3,9 @@
 <head>{{ partial "header.html" . }}</head>
 <body class="font-sans min-h-screen flex flex-col">
   {{ partial "nav.html" . }}
-  <main class="flex-grow px-2">
+  <div class="flex-grow px-2">
     {{ block "main" . }}{{ end }}
-  </main>
+  </div>
   {{ partial "footer.html" . }}
   {{ partial "image-modal.html" . }}
   {{ partial "scripts.html" . }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -11,7 +11,9 @@
     {{ end }}
   </ul>
 </main>
+{{ if ne .Site.Params.showScrollToTop false }}
 <div class="page-actions" data-pagefind-ignore>
 {{ partial "back-to-top.html" . }}
 </div>
+{{ end }}
 {{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,9 +1,9 @@
 {{ define "main" }}
 <main class="post-main mx-auto my-4 px-3 lg:px-0{{ if .Params.dropcap }} dropcap{{ end }}" data-pagefind-body>
   <div class="post-header">
-    <div class="text-3xl font-semibold text-[var(--color-heading-text)] font-sans">
+    <h1 class="text-3xl font-semibold text-[var(--color-heading-text)] font-sans">
       {{ .Title }}
-    </div>
+    </h1>
 
     <p class="text-faint text-sm mt-1 mb-4 post-meta">
       {{ if not .Date.IsZero }}<time class="text-lg">{{ .Date.Format "02 Jan 2006" }}</time> {{ end }}

--- a/layouts/_default/tag.html
+++ b/layouts/_default/tag.html
@@ -20,7 +20,9 @@
     {{ end }}
   </ul>
 </main>
+{{ if ne .Site.Params.showScrollToTop false }}
 <div class="page-actions tag-page-actions" data-pagefind-ignore>
 {{ partial "back-to-top.html" . }}
 </div>
+{{ end }}
 {{ end }}

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -13,7 +13,9 @@
     {{ end }}
   </ul>
 </main>
+{{ if ne .Site.Params.showScrollToTop false }}
 <div class="page-actions" data-pagefind-ignore>
 {{ partial "back-to-top.html" . }}
 </div>
+{{ end }}
 {{ end }}

--- a/layouts/partials/back-to-top.html
+++ b/layouts/partials/back-to-top.html
@@ -1,13 +1,13 @@
-{{ if .Site.Params.showScrollToTop | default true }}
+{{ if ne .Site.Params.showScrollToTop false }}
 <span class="text-white hover:opacity-80 hover:text-white" data-pagefind-ignore>
-  <a
+  <button
+    type="button"
     id="scroll-to-top"
     class="back-to-top-link opacity-0"
-    onclick="topFunction()"
     style="visibility: hidden; display: none; transition: opacity .5s, visibility .5s;"
-    title="back to top"
+    title="{{ T "backToTop" }}"
   >
-    back to top
-  </a>
+    {{ T "backToTop" }}
+  </button>
 </span>
 {{ end }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -5,6 +5,6 @@
   </div>
   {{ end }}
   <div class="footer-text">
-    Powered by <a href="https://gohugo.io/" target="_blank" class="hover:opacity-80">Hugo</a>, based on the <a href="https://github.com/darwin67/er" target="_blank" class="text-[var(--color-main)] hover:opacity-80">Er</a> theme. {{ with .Site.Copyright }}{{ . }}{{end}}
+    Powered by <a href="https://gohugo.io/" target="_blank" rel="noopener" class="hover:opacity-80">Hugo</a>, based on the <a href="https://github.com/darwin67/er" target="_blank" rel="noopener" class="text-[var(--color-main)] hover:opacity-80">Er</a> theme. {{ with .Site.Copyright }}{{ . }}{{end}}
   </div>
 </footer>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,12 +1,17 @@
+{{- $palette := .Site.Params.palette | default "clay" -}}
+{{- if not (in (slice "clay" "nord") $palette) -}}
+  {{- errorf "Invalid params.palette %q: expected clay or nord" $palette -}}
+{{- end -}}
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <meta content='text/html; charset=utf-8' http-equiv='content-type' />
 <meta data-pagefind-meta="title[content]" content="{{ .Title }}" />
 <meta data-pagefind-meta="summary[content]" content="{{ .Summary | plainify }}" />
 <meta data-pagefind-meta="type[content]" content="{{ .Type }}" />
+<link rel="canonical" href="{{ .Permalink }}" />
 
 <script>
-  document.documentElement.setAttribute('data-palette', '{{ .Site.Params.palette | default "clay" }}');
+  document.documentElement.setAttribute('data-palette', {{ $palette | jsonify | safeJS }});
   (function () {
     try {
       var stored = localStorage.getItem('theme');

--- a/layouts/partials/image-modal.html
+++ b/layouts/partials/image-modal.html
@@ -1,10 +1,20 @@
-<div id="image-modal" class="fixed inset-0 bg-black/75 z-50 hidden items-center justify-center" onclick="closeImageModal()" data-pagefind-ignore>
-  <div class="relative max-w-full max-h-full" onclick="event.stopPropagation()">
+<div
+  id="image-modal"
+  class="fixed inset-0 bg-black/75 z-50 hidden items-center justify-center"
+  role="dialog"
+  aria-modal="true"
+  aria-labelledby="image-modal-title"
+  hidden
+  data-pagefind-ignore
+>
+  <div class="relative max-w-full max-h-full">
+    <h2 id="image-modal-title" class="sr-only">{{ T "imagePreview" }}</h2>
     <img id="modal-image" src="" alt="" class="max-w-[90vw] max-h-[90vh] object-contain">
     <button
-      onclick="closeImageModal()"
-      class="absolute top-4 right-4 text-white text-2xl hover:text-gray-300 bg-black/50 rounded-full w-8 h-8 flex items-center justify-center"
-      aria-label="Close modal"
+      type="button"
+      id="image-modal-close"
+      class="absolute top-4 right-4 text-white text-2xl hover:text-faint bg-black/50 rounded-full w-8 h-8 flex items-center justify-center"
+      aria-label="{{ T "closeImagePreview" }}"
     >
       &times;
     </button>

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -25,82 +25,131 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 </script>
 
-{{ if or (.Site.Params.showTagCloud | default true) (.Site.Params.showScrollToTop | default true) }}
+{{ if or (ne .Site.Params.showTagCloud false) (ne .Site.Params.showScrollToTop false) }}
 <script type="text/javascript">
 var prevScrollpos = window.pageYOffset;
-window.onscroll = function() {
+window.addEventListener('scroll', function() {
   var currentScrollPos = window.pageYOffset;
 
-  {{ if .Site.Params.showTagCloud | default true }}
-  if (document.getElementById("tag-cloud") !== null) {
+  {{ if ne .Site.Params.showTagCloud false }}
+  var tagCloud = document.getElementById('tag-cloud');
+  if (tagCloud) {
     if (prevScrollpos > currentScrollPos) { // scroll up
-      document.getElementById("tag-cloud").style.visibility = "visible";
-      document.getElementById("tag-cloud").style.opacity = "1";
+      tagCloud.style.visibility = 'visible';
+      tagCloud.style.opacity = '1';
     } else {
-      document.getElementById("tag-cloud").style.visibility = "hidden";
-      document.getElementById("tag-cloud").style.opacity = "0";
+      tagCloud.style.visibility = 'hidden';
+      tagCloud.style.opacity = '0';
     }
   }
   {{ end }}
 
-  {{ if .Site.Params.showScrollToTop | default true }}
-  if (document.body.scrollTop > 1000 || document.documentElement.scrollTop > 1000) {
-      document.getElementById("scroll-to-top").style.display = "inline-flex";
-      document.getElementById("scroll-to-top").style.visibility = "visible";
-      document.getElementById("scroll-to-top").style.opacity = "1";
-  } else {
-      document.getElementById("scroll-to-top").style.visibility = "hidden";
-      document.getElementById("scroll-to-top").style.opacity = "0";
+  {{ if ne .Site.Params.showScrollToTop false }}
+  var scrollToTop = document.getElementById('scroll-to-top');
+  if (scrollToTop) {
+    if (document.body.scrollTop > 1000 || document.documentElement.scrollTop > 1000) {
+      scrollToTop.style.display = 'inline-flex';
+      scrollToTop.style.visibility = 'visible';
+      scrollToTop.style.opacity = '1';
+    } else {
+      scrollToTop.style.visibility = 'hidden';
+      scrollToTop.style.opacity = '0';
+    }
   }
   {{ end }}
   prevScrollpos = currentScrollPos;
-}
-{{ if .Site.Params.showScrollToTop | default true }}
-// When the user clicks on the button, scroll to the top of the document
-function topFunction() {
-  document.body.scrollTop = 0; // For Safari
-  document.documentElement.scrollTop = 0; // For Chrome, Firefox, IE and Opera
-}
+});
+</script>
 {{ end }}
 
-// Image modal functionality
-function openImageModal(imgSrc, imgAlt) {
-  const modal = document.getElementById('image-modal');
-  const modalImage = document.getElementById('modal-image');
-  modalImage.src = imgSrc;
-  modalImage.alt = imgAlt;
-  modal.classList.remove('hidden');
-  modal.classList.add('flex');
-  document.body.style.overflow = 'hidden';
-}
-
-function closeImageModal() {
-  const modal = document.getElementById('image-modal');
-  modal.classList.add('hidden');
-  modal.classList.remove('flex');
-  document.body.style.overflow = '';
-}
-
-// Add click handlers to all images in post content
+<script type="text/javascript">
 document.addEventListener('DOMContentLoaded', function() {
-  const images = document.querySelectorAll('.post-content img, .content img, article img');
+  var scrollToTop = document.getElementById('scroll-to-top');
+  var modal = document.getElementById('image-modal');
+  var modalImage = document.getElementById('modal-image');
+  var closeButton = document.getElementById('image-modal-close');
+  var activeImageTrigger = null;
+  var inertSiblings = [];
+  var previousBodyOverflow = '';
+
+  if (scrollToTop) {
+    scrollToTop.addEventListener('click', function() {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+  }
+
+  function openImageModal(image) {
+    activeImageTrigger = image;
+    previousBodyOverflow = document.body.style.overflow;
+    inertSiblings = Array.from(document.body.children).filter(function(element) {
+      return element !== modal && !element.inert;
+    });
+    inertSiblings.forEach(function(element) {
+      element.inert = true;
+    });
+    modalImage.src = image.currentSrc || image.src;
+    modalImage.alt = image.alt;
+    modal.hidden = false;
+    modal.classList.remove('hidden');
+    modal.classList.add('flex');
+    document.body.style.overflow = 'hidden';
+    closeButton.focus();
+  }
+
+  function closeImageModal() {
+    if (modal.hidden) return;
+
+    modal.hidden = true;
+    modal.classList.add('hidden');
+    modal.classList.remove('flex');
+    document.body.style.overflow = previousBodyOverflow;
+    inertSiblings.forEach(function(element) {
+      element.inert = false;
+    });
+    inertSiblings = [];
+    modalImage.src = '';
+    if (activeImageTrigger) activeImageTrigger.focus();
+    activeImageTrigger = null;
+  }
+
+  closeButton.addEventListener('click', closeImageModal);
+  modal.addEventListener('click', function(event) {
+    if (event.target === modal) closeImageModal();
+  });
+
+  var imagePreviewLabel = {{ T "imagePreview" | jsonify | safeJS }};
+  var images = document.querySelectorAll('.post-content img, .content img, article img');
   images.forEach(function(img) {
+    if (img.closest('a')) return;
+
     img.style.cursor = 'pointer';
+    img.setAttribute('tabindex', '0');
+    img.setAttribute('role', 'button');
+    img.setAttribute('aria-haspopup', 'dialog');
+    img.setAttribute('aria-label', img.alt ? imagePreviewLabel + ': ' + img.alt : imagePreviewLabel);
     img.addEventListener('click', function() {
-      openImageModal(this.src, this.alt);
+      openImageModal(this);
+    });
+    img.addEventListener('keydown', function(event) {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        openImageModal(this);
+      }
     });
   });
-  
-  // Close modal on Escape key
+
   document.addEventListener('keydown', function(event) {
+    if (modal.hidden) return;
+
     if (event.key === 'Escape') {
       closeImageModal();
+    } else if (event.key === 'Tab') {
+      event.preventDefault();
+      closeButton.focus();
     }
   });
 });
-
 </script>
-{{ end }}
 
 {{ if .Params.math }}
 <!-- KaTeX 0.16.9 (cdnjs) — loaded only on pages with `math: true`. -->

--- a/layouts/partials/tag_cloud.html
+++ b/layouts/partials/tag_cloud.html
@@ -1,9 +1,9 @@
 {{ $maxtags := .Site.Params.maxTags | default 50 }}
-{{ if .Site.Params.showTagCloud | default true }}
+{{ if ne .Site.Params.showTagCloud false }}
 <div class="hidden text-right fixed right-3 top-[100px] max-w-[250px] lg:block transition-opacity duration-500" id="tag-cloud" data-pagefind-ignore>
     <a href="{{ "/tags/" | relLangURL }}" class="block text-xl !text-[var(--color-main)]">{{ T "tags" }}</a>
     {{ range first $maxtags .Site.Taxonomies.tags.ByCount }}
-    <a class="text-faint no-underline text-sm" href="{{ "/tags/" | relLangURL }}{{ .Name | urlize }}">{{ .Name }}</a></li>
+    <a class="text-faint no-underline text-sm" href="{{ "/tags/" | relLangURL }}{{ .Name | urlize }}">{{ .Name }}</a>
   {{ end }}
 </div>
 {{ end }}


### PR DESCRIPTION
## Summary

- improve landmark and heading semantics, canonical metadata, and palette validation
- make image previews and back-to-top controls keyboard accessible and robust when optional features are disabled
- supervise Hugo, Tailwind, and Pagefind development watchers with a complete Nix toolchain
- add build/generated-asset CI, immutable action pins, and release-tag/build safeguards

## Verification

- `nix develop -c make build`
- `nix develop .. -c sh -c 'hugo -b http://example.test && pagefind --site public'` from `demo/`
- explicit-disabled-controls Hugo smoke build
- invalid-palette negative build
- `make dev` startup and cleanup smoke test
- workflow YAML and plan-status checks
